### PR TITLE
True 320kbps AAC files on download

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
+                "@ffmpeg/core": "^0.12.10",
+                "@ffmpeg/ffmpeg": "^0.12.15",
+                "@ffmpeg/util": "^0.12.2",
                 "dashjs": "^5.1.1",
                 "pocketbase": "^0.26.5"
             },
@@ -2401,6 +2404,45 @@
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@ffmpeg/core": {
+            "version": "0.12.10",
+            "resolved": "https://registry.npmjs.org/@ffmpeg/core/-/core-0.12.10.tgz",
+            "integrity": "sha512-dzNplnn2Nxle2c2i2rrDhqcB19q9cglCkWnoMTDN9Q9l3PvdjZWd1HfSPjCNWc/p8Q3CT+Es9fWOR0UhAeYQZA==",
+            "license": "GPL-2.0-or-later",
+            "engines": {
+                "node": ">=16.x"
+            }
+        },
+        "node_modules/@ffmpeg/ffmpeg": {
+            "version": "0.12.15",
+            "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.12.15.tgz",
+            "integrity": "sha512-1C8Obr4GsN3xw+/1Ww6PFM84wSQAGsdoTuTWPOj2OizsRDLT4CXTaVjPhkw6ARyDus1B9X/L2LiXHqYYsGnRFw==",
+            "license": "MIT",
+            "dependencies": {
+                "@ffmpeg/types": "^0.12.4"
+            },
+            "engines": {
+                "node": ">=18.x"
+            }
+        },
+        "node_modules/@ffmpeg/types": {
+            "version": "0.12.4",
+            "resolved": "https://registry.npmjs.org/@ffmpeg/types/-/types-0.12.4.tgz",
+            "integrity": "sha512-k9vJQNBGTxE5AhYDtOYR5rO5fKsspbg51gbcwtbkw2lCdoIILzklulcjJfIDwrtn7XhDeF2M+THwJ2FGrLeV6A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.x"
+            }
+        },
+        "node_modules/@ffmpeg/util": {
+            "version": "0.12.2",
+            "resolved": "https://registry.npmjs.org/@ffmpeg/util/-/util-0.12.2.tgz",
+            "integrity": "sha512-ouyoW+4JB7WxjeZ2y6KpRvB+dLp7Cp4ro8z0HIVpZVCM7AwFlHa0c4R8Y/a4M3wMqATpYKhC7lSFHQ0T11MEDw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.x"
             }
         },
         "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,10 @@
         "source-map": "^0.7.4"
     },
     "dependencies": {
-        "pocketbase": "^0.26.5",
-        "dashjs": "^5.1.1"
+        "@ffmpeg/core": "^0.12.10",
+        "@ffmpeg/ffmpeg": "^0.12.15",
+        "@ffmpeg/util": "^0.12.2",
+        "dashjs": "^5.1.1",
+        "pocketbase": "^0.26.5"
     }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,6 +7,9 @@ export default defineConfig({
         outDir: 'dist',
         emptyOutDir: true,
     },
+    optimizeDeps: {
+        exclude: ['@ffmpeg/core', '@ffmpeg/ffmpeg', '@ffmpeg/util'],
+    },
     plugins: [
         VitePWA({
             registerType: 'prompt',


### PR DESCRIPTION
Download FLAC files even when 320kbps AAC is selected and then locally convert them, as source files have lower quality than requested.

Before:
<img width="868" height="364" alt="image" src="https://github.com/user-attachments/assets/62a0c809-327e-4296-ba0a-7301a9a87719" />

After:
<img width="868" height="364" alt="image" src="https://github.com/user-attachments/assets/fee6c83b-d5f3-4d4e-bda0-22056d2d34b7" />

**Important:** This adds a significant slowdown (at least 30 extra seconds) in the download process.

**Extra notes:** I did not have much time, so I created __basic functionality__.
- I don't know if I modified all the files that had to change.
- What I am sure is there is no visual indicator that let's the user know what is going on.
- I followed this [post](https://stackoverflow.com/questions/79148853/react-vite-ffmpeg-how-to-resolve-worker-module-returning-404) but did not add the headers in the vite config file as I am note sure what they do.

Any help from the maintainers is appreciated. I also understand if this does not get merged as the slowdown might degrade user experience.