### PR TITLE
fix media key play/pause toggling on press and release events

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,7 +12,7 @@ use tauri::menu::{MenuBuilder, MenuItemBuilder};
 use tauri::image::Image;
 use tauri::tray::{TrayIconBuilder, MouseButton, MouseButtonState};
 use tauri_plugin_notification::NotificationExt;
-use tauri_plugin_global_shortcut::GlobalShortcutExt;
+use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
 use tauri_plugin_dialog::DialogExt;
 use std::path::PathBuf;
 use std::fs;
@@ -217,8 +217,10 @@ pub fn run() {
                 })
                 .build(app)?;
 
-            let _ = app.global_shortcut().on_shortcut("MediaPlayPause", |app, _shortcut, _event| {
-                let _ = app.emit("media-toggle", ());
+            let _ = app.global_shortcut().on_shortcut("MediaPlayPause", |app, _shortcut, event| {
+                if event.state == ShortcutState::Released {
+                    let _ = app.emit("media-toggle", ());
+                }
             });
 
             let window = WebviewWindowBuilder::new(


### PR DESCRIPTION
## Problem                                                                                                                                                  
The media key Play/Pause was triggering twice per key press:                                                                                      
- Once on key press (Pressed state)                                                                                                                         
- Once on key release (Released state)                                                                                                                      
                                                                                                                                                              
This caused the media player to toggle twice, canceling the intended action
  
## Solution                                                                                                                                                 
Added a check to only handle the shortcut event on `ShortcutState::Released`, ignoring the initial press event. This prevents the double toggle and ensures the media key behaves as expected.
  
**Note:** I choose to use `Released` state, but if you prefer the action to trigger on key press instead, I can change to `ShortcutState::Pressed`.