### PR TITLE
fix: Consistent text formatting in context menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,8 +45,8 @@
                 <li data-action="go-to-artist" data-type-filter="track,album">Go to artist</li>
                 <li data-action="go-to-album" data-type-filter="track">Go to album</li>
                 <li data-action="copy-link">Copy link</li>
-                <li data-action="track-info" data-type-filter="track">Track Info</li>
-                <li data-action="open-original-url" data-type-filter="track">Open Original URL</li>
+                <li data-action="track-info" data-type-filter="track">Track info</li>
+                <li data-action="open-original-url" data-type-filter="track">Open original URL</li>
                 <li data-action="download">Download</li>
             </ul>
         </div>

--- a/js/app.js
+++ b/js/app.js
@@ -1437,11 +1437,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 
                         if (track) {
                             if (albumItem) {
-                                let label = 'Album';
+                                let label = 'album';
                                 const albumType = track.album?.type?.toUpperCase();
                                 const trackCount = track.album?.numberOfTracks;
 
-                                if (albumType === 'SINGLE' || trackCount === 1) label = 'Single';
+                                if (albumType === 'SINGLE' || trackCount === 1) label = 'single';
                                 else if (albumType === 'EP') label = 'EP';
                                 else if (trackCount && trackCount <= 6) label = 'EP';
 


### PR DESCRIPTION
Removed capital letters from all words after the first one.

Before: 
<img width="171" height="384" alt="image" src="https://github.com/user-attachments/assets/8f7ace87-db17-4292-a96e-51c506e445a5" />

After: 
<img width="163" height="382" alt="image" src="https://github.com/user-attachments/assets/9ebcdcb8-e0dd-41d1-82b0-9dd01515f4fc" />
