### PR TITLE
Fix pocketbase url not being used

### DIFF
--- a/js/accounts/pocketbase.js
+++ b/js/accounts/pocketbase.js
@@ -118,7 +118,7 @@ const syncManager = {
                         }
                     }
                 } catch (error) {
-                    console.log(error);// Ignore fallback error
+                    console.log(error); // Ignore fallback error
                 }
                 return fallback;
             }


### PR DESCRIPTION
POCKETBASE_URL was 'https://monodb.samidy.com', so I kept this url as default, and replace it with the one set in settings if any.