### PR TITLE
fix copy-link action menu

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -1057,7 +1057,13 @@ export async function handleTrackAction(
             navigate(`/album/${item.album.id}`);
         }
     } else if (action === 'copy-link' || action === 'share') {
-        const url = `${window.location.origin}/track/${item.id}`;
+        // Use stored href from card if available, otherwise construct URL
+        const contextMenu = document.getElementById('context-menu');
+        const storedHref = contextMenu?._contextHref;
+        const url = storedHref
+            ? `${window.location.origin}${storedHref}`
+            : `${window.location.origin}/track/${item.id || item.uuid}`;
+
         navigator.clipboard.writeText(url).then(() => {
             showNotification('Link copied to clipboard!');
         });
@@ -1481,6 +1487,7 @@ export function initializeTrackInteractions(player, api, mainContent, contextMen
             contextTrack = item;
             contextMenu._contextTrack = item;
             contextMenu._contextType = type.replace('userplaylist', 'user-playlist');
+            contextMenu._contextHref = card.dataset.href;
 
             await updateContextMenuLikeState(contextMenu, item);
             positionMenu(contextMenu, e.pageX, e.pageY);


### PR DESCRIPTION
Fix "copy link" action button.

Before => was always copying /track/id

Now => take the card's href and add it to clipboard

/!\ Note that if it can't find the card's href, it will naively "create" a link, but it will always be a `/track/id`... Perhaps this needs improvement for a smarter system. Or we could assume the href is always populated and therefore we don't care?