### PR TITLE
Fix sidebar nav button clipping on hover

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -6095,7 +6095,6 @@ textarea:focus {
     display: flex;
     flex-direction: column;
     height: 100%;
-    overflow: hidden;
 }
 
 .sidebar-nav.main {


### PR DESCRIPTION
Sidebar nav links use a hover effect `transform: translateX(4px)` so they indent slightly. That shift was getting clipped by the sidebar edge, so the right side of the button (and its background) was cut off on hover.

First image: the current state, showing the button clipping.
Second image: the change, no more clipping.

<img width="210" height="153" alt="Screenshot 2026-02-14 at 21 57 52" src="https://github.com/user-attachments/assets/1437917d-daf6-494b-8758-4d46ae977569" />
<img width="210" height="154" alt="Screenshot 2026-02-14 at 21 57 25" src="https://github.com/user-attachments/assets/8b4d0c71-6513-4b65-b64e-1d46c973f0f1" />
