### PR TITLE
fix: restore iOS background play by detecting iOS before UA spoof

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,10 @@
 <html lang="en">
     <head>
         <script>
+            // Capture real iOS state before spoofing (needed for background audio)
+            var _ua = navigator.userAgent.toLowerCase();
+            window.__IS_IOS__ = /iphone|ipad|ipod/.test(_ua) || (_ua.includes('mac') && navigator.maxTouchPoints > 1);
+
             // Spoof User-Agent to bypass Google's embedded browser check
             Object.defineProperty(navigator, 'userAgent', {
                 get: function () {

--- a/js/app.js
+++ b/js/app.js
@@ -234,8 +234,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     const audioPlayer = document.getElementById('audio-player');
 
     // i love ios and macos!!!! webkit fucking SUCKS BULLSHIT sorry ios/macos heads yall getting lossless only
+    // Use window.__IS_IOS__ (set before UA spoof in index.html) so detection works on real iOS.
+    const isIOS = typeof window !== 'undefined' && window.__IS_IOS__ === true;
     const ua = navigator.userAgent.toLowerCase();
-    const isIOS = /iphone|ipad|ipod/.test(ua) || (ua.includes('mac') && navigator.maxTouchPoints > 1);
     const isSafari =
         ua.includes('safari') && !ua.includes('chrome') && !ua.includes('crios') && !ua.includes('android');
 

--- a/js/audio-context.js
+++ b/js/audio-context.js
@@ -137,9 +137,9 @@ class AudioContextManager {
 
         // Detect iOS - skip Web Audio initialization on iOS to avoid lock screen audio issues
         // iOS suspends AudioContext when screen locks, and MediaSession controls don't count
-        // as user gestures to resume it, causing audio to play silently
-        const ua = navigator.userAgent.toLowerCase();
-        const isIOS = /iphone|ipad|ipod/.test(ua) || (ua.includes('mac') && navigator.maxTouchPoints > 1);
+        // as user gestures to resume it, causing audio to play silently.
+        // Use window.__IS_IOS__ (set before UA spoof in index.html) so detection works on real iOS.
+        const isIOS = typeof window !== 'undefined' && window.__IS_IOS__ === true;
         if (isIOS) {
             console.log('[AudioContext] Skipping Web Audio initialization on iOS for lock screen compatibility');
             // Don't set isInitialized - let it remain false so isReady() returns false


### PR DESCRIPTION
On iOS, playback stops when the app is backgrounded, the screen is locked, or the device sleeps.

**Root Cause:**
The app spoofs `navigator.userAgent` in `index.html`. After that, all UA reads return a non IOS UA string, including on real iPhones.

iOS detection in `audio-context.js` and `app.js` was done via `navigator.userAgent`. On iOS, that check therefore failed, so the app thought it wasn’t on iOS and initialised the Web Audio API.

**Solution:**
Before applying the UA spoof, the inline script in `index.html` now stores the real iOS state in `window.__IS_IOS__` (using the real navigator.userAgent and navigator.maxTouchPoints).

Fixes https://github.com/monochrome-music/monochrome/issues/189, https://github.com/monochrome-music/monochrome/issues/135