### PR TITLE
Fix bottom sidebar bottom buttons clipping on hover

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -6106,7 +6106,6 @@ textarea:focus {
     display: flex;
     flex-direction: column;
     min-height: 0;
-    overflow: hidden;
 }
 
 #pinned-items-nav {


### PR DESCRIPTION
Extends: https://github.com/monochrome-music/monochrome/pull/190

I previously created a fix for the sidebar buttons clipping, but the fix didn’t cover the bottom section. Buttons inside `sidebar-bottom-container` (About, Discord, Download) were still clipped. This PR applies the same clipping fix to the bottom sidebar so those items render correctly and no longer get cut off.

First image: the current state, showing the button clipping.
Second image: the change, no more clipping.

<img width="209" height="169" alt="Screenshot 2026-02-15 at 13 39 34" src="https://github.com/user-attachments/assets/fa2b83d1-c798-4072-9a8c-a5ce271446dd" />
<img width="209" height="169" alt="Screenshot 2026-02-15 at 13 39 14" src="https://github.com/user-attachments/assets/e68fbb26-646b-4aba-8dfd-c4bc45d0081a" />
