### PR TITLE
Proposal: shrink bottom nav items as secondary actions

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -388,6 +388,18 @@ kbd {
     padding: 0;
 }
 
+.sidebar-nav.bottom .nav-item a {
+    padding: 0.5rem 0.75rem;
+    gap: 0.5rem;
+    font-size: 0.8125rem;
+    font-weight: 500;
+}
+
+.sidebar-nav.bottom .nav-item a svg {
+    width: 17px;
+    height: 17px;
+}
+
 .main-content {
     grid-area: main;
     overflow-y: auto;


### PR DESCRIPTION
Reduces the visual size of the sidebar bottom section (About, Discord, Download) so they read as secondary actions rather than primary navigation.

The bottom items are used less often than Home, Library, Recent, Settings, etc. Giving them slightly smaller typography and spacing makes the hierarchy clearer and keeps focus on the main nav.

First image: Current size, bottom nav items are the same size as the primary actions.
Second image: Updates size, items are now smaller and act as secondary actions.

<div>
<img width="49%" height="1311" alt="Screenshot 2026-02-15 at 22 29 05" src="https://github.com/user-attachments/assets/9a57e3c0-d78f-4069-beb9-b7378fa5921a" />
<img width="49%" height="1311" alt="Screenshot 2026-02-15 at 22 26 50" src="https://github.com/user-attachments/assets/d4084a7b-7306-4a87-b94f-44bc28493e25" />
</div>