### PR TITLE
fix(player): Uniform shuffle

### DIFF
--- a/js/player.js
+++ b/js/player.js
@@ -681,7 +681,10 @@ export class Player {
                 tracksToShuffle.splice(this.currentQueueIndex, 1);
             }
 
-            tracksToShuffle.sort(() => Math.random() - 0.5);
+            for (let i = tracksToShuffle.length - 1; i > 0; i--) {
+                 const j = Math.floor(Math.random() * (i + 1));
+                 [tracksToShuffle[i], tracksToShuffle[j]] = [tracksToShuffle[j], tracksToShuffle[i]];
+            }
 
             if (currentTrack) {
                 this.shuffledQueue = [currentTrack, ...tracksToShuffle];


### PR DESCRIPTION
Replaces the current naive solution with Fisher-Yates, fixes #226 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the shuffle algorithm to provide more uniform randomization of track order, ensuring better distribution of songs when shuffle mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->