### PR TITLE
Python3 Installation and Tailscale Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,11 @@ WORKDIR /app
 
 # Install system dependencies required for Bun and Neutralino
 RUN apk add --no-cache wget curl bash
+RUN apk add --no-cache python3 make g++ && ln -sf python3 /usr/bin/python
 
 # Install Bun
 RUN curl -fsSL https://bun.sh/install | bash
+
 # Add Bun to PATH so it can be used in subsequent steps
 ENV PATH="/root/.bun/bin:${PATH}"
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,8 +19,14 @@ export default defineConfig(({ mode }) => {
         server: {
             fs: {
                 allow: ['.', 'node_modules'],
+                // host: true,
+                // allowedHosts: ['<device_specific_tailscale_magic_dns_name>'], // e.g. pi5.tailf5f622.ts.net
             },
         },
+        // preview: {
+        //     host: true,
+        //     allowedHosts: ['<device_specific_tailscale_magic_dns_name>'], // e.g. pi5.tailf5f622.ts.net
+        // },
         build: {
             outDir: 'dist',
             emptyOutDir: true,


### PR DESCRIPTION
When tried installing it with docker in my raspberry pi 5, I got python3 dependency errors. Adding that one line in the Dockerfile fixed it. After that I wanted to be able to access it from tailscale and I was getting "forbidden" without the access rules inside 'vite.config.js'. Now I'm enjoing your awesome docker container from anywhere!

Changes:
1. Add python3 installation to Dockerfile
2. Add tailscale optional support

### Description
### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist
- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.

---
*By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment with additional system dependencies.
  * Added configuration options in build configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->