### PR TITLE
fix(downloads): write full track title to metadata

### DIFF
--- a/js/id3-writer.js
+++ b/js/id3-writer.js
@@ -1,10 +1,10 @@
-import { getCoverBlob } from './utils.js';
+import { getCoverBlob, getTrackTitle } from './utils.js';
 
 async function writeID3v2Tag(mp3Blob, metadata, coverBlob = null) {
     const frames = [];
 
     if (metadata.title) {
-        frames.push(createTextFrame('TIT2', metadata.title));
+        frames.push(createTextFrame('TIT2', getTrackTitle(metadata)));
     }
 
     const artistName = metadata.artist?.name || metadata.artists?.[0]?.name;

--- a/js/metadata.js
+++ b/js/metadata.js
@@ -1,4 +1,4 @@
-import { getCoverBlob, detectAudioFormat } from './utils.js';
+import { getCoverBlob, detectAudioFormat, getTrackTitle } from './utils.js';
 import { addMp3Metadata } from './id3-writer.js';
 
 const VENDOR_STRING = 'Monochrome';
@@ -565,7 +565,7 @@ function createVorbisCommentBlock(track) {
 
     // Add standard tags
     if (track.title) {
-        comments.push(['TITLE', track.title]);
+        comments.push(['TITLE', getTrackTitle(track)]);
     }
     const artistStr = getFullArtistString(track);
     if (artistStr) {
@@ -930,7 +930,7 @@ function createMp4MetadataAtoms(track) {
     // We'll create basic iTunes-style metadata
 
     const tags = {
-        '©nam': track.title || DEFAULT_TITLE,
+        '©nam': getTrackTitle(track) || DEFAULT_TITLE,
         '©ART': getFullArtistString(track) || DEFAULT_ARTIST,
         '©alb': track.album?.title || DEFAULT_ALBUM,
         aART: track.album?.artist?.name || track.artist?.name || DEFAULT_ARTIST,


### PR DESCRIPTION
### Description
The version portion of the title is now written to the metadata.

Without this, certain details like `(Acapella)` weren't being properly included in the track title.

### Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist
- [X] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [X] **I understand every line of code I am submitting.**
- [X] I have tested these changes locally, and they work as expected.

---
*By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced track title extraction to ensure consistent handling across all supported audio metadata formats (ID3v2, Vorbis comments, and MP4 atoms).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->