### PR TITLE
feat: fix ios lockscreen controls

### DIFF
--- a/js/player.js
+++ b/js/player.js
@@ -258,8 +258,8 @@ export class Player {
 
         const setHandlers = () => {
             navigator.mediaSession.setActionHandler('play', async () => {
-            // Initialize and resume audio context first (required for iOS lock screen)
-            // Must happen before audio.play() or audio won't route through Web Audio
+                // Initialize and resume audio context first (required for iOS lock screen)
+                // Must happen before audio.play() or audio won't route through Web Audio
                 if (!audioContextManager.isReady()) {
                     audioContextManager.init(this.audio);
                     this.applyReplayGain();
@@ -270,7 +270,7 @@ export class Player {
                     await this.audio.play();
                 } catch (e) {
                     console.error('MediaSession play failed:', e);
-                // If play fails, try to handle it like a regular play/pause
+                    // If play fails, try to handle it like a regular play/pause
                     this.handlePlayPause();
                 }
             });
@@ -280,7 +280,7 @@ export class Player {
             });
 
             navigator.mediaSession.setActionHandler('previoustrack', async () => {
-            // Ensure audio context is active for iOS lock screen controls
+                // Ensure audio context is active for iOS lock screen controls
                 if (!audioContextManager.isReady()) {
                     audioContextManager.init(this.audio);
                     this.applyReplayGain();
@@ -290,7 +290,7 @@ export class Player {
             });
 
             navigator.mediaSession.setActionHandler('nexttrack', async () => {
-            // Ensure audio context is active for iOS lock screen controls
+                // Ensure audio context is active for iOS lock screen controls
                 if (!audioContextManager.isReady()) {
                     audioContextManager.init(this.audio);
                     this.applyReplayGain();


### PR DESCRIPTION
### Description
Fixes lock screen / Control Center playback controls on iOS so they show previous/next track instead of +10 / -10 seconds.

**Before / After:**
<div>
<img width="49%" height="1398" alt="IMG_2738" src="https://github.com/user-attachments/assets/91e2614b-2c70-46e5-a315-0bcbc4bf7a0d" />
<img width="49%" height="1398" alt="IMG_2739" src="https://github.com/user-attachments/assets/f1bcdcff-b585-4c9e-aee3-dd2e7df18258" />
</div>

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist
- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.

---
*By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media control handling with better error recovery for playback actions.
  * Enhanced media control support on iOS devices with platform-specific optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->