### PR TITLE
feat(downloads): save replay gain tags to FLAC metadata

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -1254,7 +1254,18 @@ export class LosslessAPI {
                         message: 'Adding metadata...',
                     });
                 }
-                blob = await addMetadataToAudio(blob, track, this, quality);
+
+                const enrichedTrack = { ...track };
+                if (lookup.info) {
+                    enrichedTrack.replayGain = {
+                        trackReplayGain: lookup.info.trackReplayGain,
+                        trackPeakAmplitude: lookup.info.trackPeakAmplitude,
+                        albumReplayGain: lookup.info.albumReplayGain,
+                        albumPeakAmplitude: lookup.info.albumPeakAmplitude,
+                    };
+                }
+
+                blob = await addMetadataToAudio(blob, enrichedTrack, this, quality);
             }
 
             // Detect actual format and fix filename extension if needed

--- a/js/downloads.js
+++ b/js/downloads.js
@@ -323,6 +323,15 @@ async function downloadTrackBlob(track, quality, api, lyricsManager = null, sign
         }
     }
 
+    if (lookup.info) {
+        enrichedTrack.replayGain = {
+            trackReplayGain: lookup.info.trackReplayGain,
+            trackPeakAmplitude: lookup.info.trackPeakAmplitude,
+            albumReplayGain: lookup.info.albumReplayGain,
+            albumPeakAmplitude: lookup.info.albumPeakAmplitude,
+        };
+    }
+
     // Handle DASH streams (blob URLs)
     let blob;
     if (streamUrl.startsWith('blob:')) {

--- a/js/metadata.js
+++ b/js/metadata.js
@@ -587,6 +587,13 @@ function createVorbisCommentBlock(track) {
     if (track.album?.numberOfTracks) {
         comments.push(['TRACKTOTAL', String(track.album.numberOfTracks)]);
     }
+    if (track.replayGain) {
+        const { albumReplayGain, albumPeakAmplitude, trackReplayGain, trackPeakAmplitude } = track.replayGain;
+        if (albumReplayGain) comments.push(['REPLAYGAIN_ALBUM_GAIN', String(albumReplayGain)]);
+        if (albumPeakAmplitude) comments.push(['REPLAYGAIN_ALBUM_PEAK', String(albumPeakAmplitude)]);
+        if (trackReplayGain) comments.push(['REPLAYGAIN_TRACK_GAIN', String(trackReplayGain)]);
+        if (trackPeakAmplitude) comments.push(['REPLAYGAIN_TRACK_PEAK', String(trackPeakAmplitude)]);
+    }
 
     const releaseDateStr =
         track.album?.releaseDate || (track.streamStartDate ? track.streamStartDate.split('T')[0] : '');


### PR DESCRIPTION
### Description
ReplayGain tags (album gain/peak, track gain/peak) are now written as part of the FLAC metadata when downloading FLAC files.

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist
- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.

---
*By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Downloaded FLAC files now include embedded ReplayGain metadata (track and album gain values plus peak amplitudes) when available.
  * ReplayGain values are attached during the download process so downloads consistently carry normalization data.
  * The ReplayGain tags are written into the FLAC Vorbis comment block so players that support ReplayGain can read them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->