### PR TITLE
feat: add mouse wheel support for fullscreen volume control

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -1351,17 +1351,22 @@ export class UIRenderer {
                 const currentVolume = this.player.userVolume;
                 const newVolume = Math.max(0, Math.min(1, currentVolume + delta));
 
-                if (delta > 0 && this.player.muted) {
-                    this.player.setMute(false);
+                if (delta > 0 && audioPlayer.muted) {
+                    audioPlayer.muted = false;
+                    localStorage.setItem('muted', false);
                 }
 
                 this.player.setVolume(newVolume);
                 updateFsVolumeUI();
             };
 
-            [fsVolumeBar, fsVolumeBtn].forEach((el) =>
-                el.addEventListener('wheel', handleFsVolumeWheel, { passive: false })
-            );
+            [fsVolumeBar, fsVolumeBtn].forEach((el) => {
+                if (el._fsVolumeWheelHandler) {
+                    el.removeEventListener('wheel', el._fsVolumeWheelHandler);
+                }
+                el._fsVolumeWheelHandler = handleFsVolumeWheel;
+                el.addEventListener('wheel', handleFsVolumeWheel, { passive: false });
+            });
 
             const setFsVolume = (e) => {
                 const rect = fsVolumeBar.getBoundingClientRect();


### PR DESCRIPTION
Added event handler to allow adjusting the fullscreen volume using the mouse wheel. Scrolling up unmutes and increases volume, scrolling down decreases volume.

### Description

To implement mouse wheel volume control in fullscreen mode, I first investigated how the volume adjustment via mouse wheel was handled in the standard (non-fullscreen) player interface. The existing event handler and logic for volume changes were reviewed, focusing on how the wheel event was processed and how the volume/mute state was updated.

After understanding the current implementation, I replicated the event handler for the fullscreen volume elements (fsVolumeBar and fsVolumeBtn). The new handler follows the same logic: scrolling up unmutes and increases the volume, scrolling down decreases it, and volume values are clamped between 0 and 1. The event is attached with { passive: false } to ensure proper prevention of default scrolling behavior.

This approach ensures consistency in user experience between normal and fullscreen modes, reusing proven logic and minimizing the risk of regressions. No changes were made to the core volume logic only the event binding and handler were adapted for fullscreen elements.

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist
- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.

---
*By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted.*



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mouse-wheel support for fullscreen volume controls. Users can scroll on the fullscreen volume button or bar to change volume in small increments (clamped to 0–100%). Increasing volume from a muted state will unmute and the fullscreen volume UI updates accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->