### PR TITLE
fix(library): show playlist in library on csv import

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1594,7 +1594,6 @@ document.addEventListener('DOMContentLoaded', async () => {
                                     }`
                                 );
                                 progressElement.style.display = 'none';
-                                return;
                             }
 
                             tracks = result.tracks;


### PR DESCRIPTION
### Description
Fixes an issue where creating a playlist through CSV import would fail to
reach the playlist creation step because the code returned early during
library import detection.

When the CSV contained album or artist metadata, the `isLibraryImport`
condition evaluated to true, causing the function to return before
`db.createPlaylist()` was executed.

Fixes #315 

### Changes
- Adjusted library import detection logic
- Ensured playlist creation flow continues for standard CSV playlist imports

### Steps to Reproduce
1. Import a CSV playlist containing artist/album columns
2. Attempt to create a playlist
3. Playlist creation does not occur

### Expected Behaviour
Playlist should be created with imported tracks.

### Testing
- Tested CSV imports with only tracks
- Tested CSV imports containing album/artist columns

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist
- [x] **I have read the [Contributing Guidelines](../CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.

---
*By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an initialization issue that prevented the application from fully completing its startup process, ensuring all features load correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->