### PR TITLE
Fixed Reset Local Data

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -3125,7 +3125,20 @@ export function initializeSettings(scrobbler, player, api, ui) {
 
                     // Clear IndexedDB - try to clear individual stores, fallback to deleting database
                     try {
-                        const stores = ['tracks', 'albums', 'artists', 'playlists', 'settings', 'history'];
+                        const stores = [
+                            'favorites_tracks',
+                            'favorites_videos',
+                            'favorites_albums',
+                            'favorites_artists',
+                            'favorites_playlists',
+                            'favorites_mixes',
+                            'history_tracks',
+                            'user_playlists',
+                            'user_folders',
+                            'settings',
+                            'pinned_items',
+                        ];
+
                         for (const storeName of stores) {
                             try {
                                 await db.performTransaction(storeName, 'readwrite', (store) => store.clear());
@@ -3133,11 +3146,12 @@ export function initializeSettings(scrobbler, player, api, ui) {
                                 // Store might not exist, continue
                             }
                         }
+
                     } catch (dbError) {
                         console.log('Could not clear IndexedDB stores:', dbError);
                         // Try to delete the entire database as fallback
                         try {
-                            const deleteRequest = indexedDB.deleteDatabase('monochromeDB');
+                            const deleteRequest = indexedDB.deleteDatabase('MonochromeDB');
                             await new Promise((resolve, reject) => {
                                 deleteRequest.onsuccess = resolve;
                                 deleteRequest.onerror = reject;


### PR DESCRIPTION
### Description

The "Reset Local Data" doesn't work because it tries to deleted the Wrong database Name "monochromeDB", but The actual database name is MonochromeDB (capital M), and Also the IndexedDB uses old stores.


### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist
- [X] **I have read the [Contributing Guidelines](../CONTRIBUTING.md).**
- [X] **I understand every line of code I am submitting.**
- [X] I have tested these changes locally, and they work as expected.

---
*By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data clearing functionality to remove additional data types including favorites, history, user data, and pinned items when resetting the application.
  * Fixed database reference issue in the reset process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->