### PR TITLE
Fix Clear Recently played

### DIFF
--- a/js/accounts/pocketbase.js
+++ b/js/accounts/pocketbase.js
@@ -303,6 +303,13 @@ const syncManager = {
         await this._updateUserJSON(user.$id, 'history', newHistory);
     },
 
+    async clearHistory() {
+        const user = authManager.user;
+        if (!user) return;
+
+        await this._updateUserJSON(user.$id, 'history', []);
+    },
+
     async syncUserPlaylist(playlist, action) {
         const user = authManager.user;
         if (!user) return;

--- a/js/ui.js
+++ b/js/ui.js
@@ -4451,6 +4451,7 @@ export class UIRenderer {
                     if (confirm('Clear all recently played tracks? This cannot be undone.')) {
                         try {
                             await db.clearHistory();
+                            await syncManager.clearHistory();
                             container.innerHTML = createPlaceholder("You haven't played any tracks yet.");
                             clearBtn.style.display = 'none';
                         } catch (err) {


### PR DESCRIPTION
### Description

The “Clear History” button was only removing the play history from IndexedDB (local storage). After reloading the app, the history would reappear because it was still stored in the cloud (PocketBase) and got synced back.

This PR fixes the issue by ensuring that when Clear History is triggered, the history is deleted from both local IndexedDB and the PocketBase store, preventing it from being re-imported after a reload.

### Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist
- [X] **I have read the [Contributing Guidelines](../CONTRIBUTING.md).**
- [X] **I understand every line of code I am submitting.**
- [X] I have tested these changes locally, and they work as expected.

---
*By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Added the ability to clear your history with automatic synchronization across all connected services. When you clear your history, changes are automatically synchronized in real-time across your entire account and all linked platforms, ensuring complete data consistency and giving you full control over your personal information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->