### PR TITLE
Enhance Docker and environment variable handling for authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,14 @@ WORKDIR /app
 RUN apk add --no-cache wget curl bash
 RUN apk add --no-cache python3 make g++ && ln -sf python3 /usr/bin/python
 
+# Accept build arguments for environment variables
+ARG AUTH_ENABLED
+ARG AUTH_SECRET
+ARG APPWRITE_ENDPOINT
+ARG APPWRITE_PROJECT_ID
+ARG POCKETBASE_URL
+ARG SESSION_MAX_AGE
+
 # Copy package files first for caching
 COPY package.json package-lock.json ./
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,16 +4,16 @@ services:
         build:
             context: .
             dockerfile: Dockerfile
+            args:
+                - AUTH_ENABLED=${AUTH_ENABLED}
+                - AUTH_SECRET=${AUTH_SECRET}
+                - APPWRITE_ENDPOINT=${APPWRITE_ENDPOINT}
+                - APPWRITE_PROJECT_ID=${APPWRITE_PROJECT_ID}
+                - POCKETBASE_URL=${POCKETBASE_URL}
+                - SESSION_MAX_AGE=${SESSION_MAX_AGE}
         container_name: monochrome
         ports:
             - '${MONOCHROME_PORT:-3000}:4173'
-        environment:
-            AUTH_ENABLED: ${AUTH_ENABLED:-false}
-            AUTH_SECRET: ${AUTH_SECRET:-}
-            APPWRITE_ENDPOINT: ${APPWRITE_ENDPOINT:-https://auth.yourdomain.com/v1}
-            APPWRITE_PROJECT_ID: ${APPWRITE_PROJECT_ID:-auth-for-monochrome}
-            POCKETBASE_URL: ${POCKETBASE_URL:-}
-            SESSION_MAX_AGE: ${SESSION_MAX_AGE:-604800000}
         restart: unless-stopped
         networks:
             - monochrome-network

--- a/js/accounts/pocketbase.js
+++ b/js/accounts/pocketbase.js
@@ -5,7 +5,7 @@ import { authManager } from './auth.js';
 
 const PUBLIC_COLLECTION = 'public_playlists';
 const DEFAULT_POCKETBASE_URL = 'https://data.samidy.xyz';
-const POCKETBASE_URL = localStorage.getItem('monochrome-pocketbase-url') || DEFAULT_POCKETBASE_URL;
+const POCKETBASE_URL = window.__POCKETBASE_URL__ || localStorage.getItem('monochrome-pocketbase-url') || DEFAULT_POCKETBASE_URL;
 
 console.log('[PocketBase] Using URL:', POCKETBASE_URL);
 

--- a/vite-plugin-auth-gate.js
+++ b/vite-plugin-auth-gate.js
@@ -19,6 +19,33 @@ function parseBody(req) {
     });
 }
 
+function buildInjectionScript(env) {
+    const AUTH_ENABLED = (env.AUTH_ENABLED ?? 'false') !== 'false';
+    const APPWRITE_ENDPOINT = env.APPWRITE_ENDPOINT;
+    const APPWRITE_PROJECT_ID = env.APPWRITE_PROJECT_ID;
+    const POCKETBASE_URL = env.POCKETBASE_URL;
+    const AUTH_GOOGLE_ENABLED = env.AUTH_GOOGLE_ENABLED;
+    const AUTH_EMAIL_ENABLED = env.AUTH_EMAIL_ENABLED;
+
+    const flags = [];
+    if (AUTH_ENABLED) flags.push('window.__AUTH_GATE__=true');
+    const authProviderOverrides = {};
+    if (AUTH_GOOGLE_ENABLED !== undefined) {
+        authProviderOverrides.google = AUTH_GOOGLE_ENABLED !== 'false';
+    }
+    if (AUTH_EMAIL_ENABLED !== undefined) {
+        authProviderOverrides.password = AUTH_EMAIL_ENABLED !== 'false';
+    }
+    if (Object.keys(authProviderOverrides).length > 0) {
+        flags.push(`window.__AUTH_PROVIDERS__=${JSON.stringify(authProviderOverrides)}`);
+    }
+    if (APPWRITE_ENDPOINT) flags.push(`window.__APPWRITE_ENDPOINT__=${JSON.stringify(APPWRITE_ENDPOINT)}`);
+    if (APPWRITE_PROJECT_ID) flags.push(`window.__APPWRITE_PROJECT_ID__=${JSON.stringify(APPWRITE_PROJECT_ID)}`);
+    if (POCKETBASE_URL) flags.push(`window.__POCKETBASE_URL__=${JSON.stringify(POCKETBASE_URL)}`);
+
+    return flags.length > 0 ? `<script>${flags.join(';')};</script>` : null;
+}
+
 export default function authGatePlugin() {
     let env = {};
 
@@ -29,33 +56,13 @@ export default function authGatePlugin() {
             env = loadEnv(mode, process.cwd(), '');
         },
 
+        transformIndexHtml(html) {
+            const scriptTag = buildInjectionScript(env);
+            return scriptTag ? html.replace('</head>', `${scriptTag}\n</head>`) : html;
+        },
+
         configurePreviewServer(server) {
-            const AUTH_ENABLED = (env.AUTH_ENABLED ?? 'false') !== 'false';
-            const APPWRITE_ENDPOINT = env.APPWRITE_ENDPOINT;
-            const APPWRITE_PROJECT_ID = env.APPWRITE_PROJECT_ID;
-            const POCKETBASE_URL = env.POCKETBASE_URL;
-            const AUTH_GOOGLE_ENABLED = env.AUTH_GOOGLE_ENABLED;
-            const AUTH_EMAIL_ENABLED = env.AUTH_EMAIL_ENABLED;
-
-            // --- Build injection script (always, for both auth gate and env config) ---
-
-            const flags = [];
-            if (AUTH_ENABLED) flags.push('window.__AUTH_GATE__=true');
-            const authProviderOverrides = {};
-            if (AUTH_GOOGLE_ENABLED !== undefined) {
-                authProviderOverrides.google = AUTH_GOOGLE_ENABLED !== 'false';
-            }
-            if (AUTH_EMAIL_ENABLED !== undefined) {
-                authProviderOverrides.password = AUTH_EMAIL_ENABLED !== 'false';
-            }
-            if (Object.keys(authProviderOverrides).length > 0) {
-                flags.push(`window.__AUTH_PROVIDERS__=${JSON.stringify(authProviderOverrides)}`);
-            }
-            if (APPWRITE_ENDPOINT) flags.push(`window.__APPWRITE_ENDPOINT__=${JSON.stringify(APPWRITE_ENDPOINT)}`);
-            if (APPWRITE_PROJECT_ID)
-                flags.push(`window.__APPWRITE_PROJECT_ID__=${JSON.stringify(APPWRITE_PROJECT_ID)}`);
-            if (POCKETBASE_URL) flags.push(`window.__POCKETBASE_URL__=${JSON.stringify(POCKETBASE_URL)}`);
-            const configScript = flags.length > 0 ? `<script>${flags.join(';')};</script>` : null;
+            const configScript = buildInjectionScript(env);
 
             // --- Pre-build injected HTML pages ---
 
@@ -69,6 +76,7 @@ export default function authGatePlugin() {
             }
 
             let loginHtml = null;
+            const AUTH_ENABLED = (env.AUTH_ENABLED ?? 'false') !== 'false';
             if (AUTH_ENABLED) {
                 const loginPath = join(distDir, 'login.html');
                 if (existsSync(loginPath)) {
@@ -98,7 +106,7 @@ export default function authGatePlugin() {
                     process.exit(1);
                 }
 
-                console.log(`Auth gate enabled (Project: ${APPWRITE_PROJECT_ID})`);
+                console.log(`Auth gate enabled (Project: ${env.APPWRITE_PROJECT_ID})`);
 
                 server.middlewares.use(
                     cookieSession({


### PR DESCRIPTION
### Description

Fixes Docker auth env vars so the app runs correctly in container mode.

- Dockerfile now accepts auth vars (`AUTH_ENABLED`, `AUTH_SECRET`, `APPWRITE_*`, `POCKETBASE_URL`, `SESSION_MAX_AGE`).
- docker-compose now passes those values to build.
- auth plugin now injects flags into the HTML so browser can read auth settings.
- PocketBase client now uses injected `window.__POCKETBASE_URL__` before the old default.

### Why this matters
Previously, auth settings could be lost in the build/deploy flow, causing login/auth gate to be wrong in Docker. This change makes env var behavior consistent and easier to configure.

### Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist
- [X] **I have read the [Contributing Guidelines](../CONTRIBUTING.md).**
- [X] **I understand every line of code I am submitting.**
- [X] I have tested these changes locally, and they work as expected.

---
*By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to accept build-time arguments for authentication and service endpoints.
  * Migrated configuration from runtime environment variables to build-time arguments in deployment setup.

* **Refactor**
  * Improved URL resolution with fallback options for external service configuration.
  * Consolidated internal script injection logic for cleaner builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->