### PR TITLE
feat(ui): add "In Your Library" section to artist detail page

### DIFF
--- a/index.html
+++ b/index.html
@@ -3297,13 +3297,15 @@
                         <div class="track-list" id="artist-detail-tracks"></div>
                     </section>
                     <section class="content-section" id="artist-section-in-library" style="display: none">
-                        <h2 class="section-title in-library-toggle" id="in-library-toggle" style="cursor: pointer; display: flex; align-items: center; gap: 0.5rem; user-select: none;">
-                            In Your Library
-                            <svg id="in-library-chevron" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="transition: transform 0.25s ease; flex-shrink: 0;">
-                                <polyline points="9 18 15 12 9 6"></polyline>
-                            </svg>
+                        <h2 class="section-title">
+                            <button id="in-library-toggle" aria-expanded="false" aria-controls="artist-detail-in-library" style="background: none; border: none; color: inherit; font: inherit; cursor: pointer; display: flex; align-items: center; gap: 0.5rem; padding: 0; user-select: none;">
+                                In Your Library
+                                <svg id="in-library-chevron" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="transition: transform 0.25s ease; flex-shrink: 0;">
+                                    <polyline points="9 18 15 12 9 6"></polyline>
+                                </svg>
+                            </button>
                         </h2>
-                        <div class="track-list" id="artist-detail-in-library" style="display: none;"></div>
+                        <div class="track-list" id="artist-detail-in-library" hidden></div>
                     </section>
                     <section class="content-section">
                         <h2 class="section-title">Albums</h2>

--- a/js/db.js
+++ b/js/db.js
@@ -585,6 +585,7 @@ export class MusicDatabase {
 
         // TRIGGER SYNC
         this._dispatchPlaylistSync('create', playlist);
+        window.dispatchEvent(new CustomEvent('playlist-tracks-changed'));
 
         return playlist;
     }
@@ -657,6 +658,7 @@ export class MusicDatabase {
 
         // TRIGGER SYNC (but for deleting)
         this._dispatchPlaylistSync('delete', { id: playlistId });
+        window.dispatchEvent(new CustomEvent('playlist-tracks-changed'));
     }
 
     async getPlaylist(playlistId) {

--- a/js/ui.js
+++ b/js/ui.js
@@ -3953,11 +3953,13 @@ export class UIRenderer {
         if (inLibrarySection) inLibrarySection.style.display = 'none';
         if (inLibraryContainer) {
             inLibraryContainer.innerHTML = '';
-            inLibraryContainer.style.display = 'none';
+            inLibraryContainer.hidden = true;
         }
-        // Reset chevron state
+        // Reset chevron and toggle state
         const chevronEl = document.getElementById('in-library-chevron');
         if (chevronEl) chevronEl.style.transform = 'rotate(0deg)';
+        const toggleBtn = document.getElementById('in-library-toggle');
+        if (toggleBtn) toggleBtn.setAttribute('aria-expanded', 'false');
 
         try {
             const artist = await this.api.getArtist(artistId, provider);
@@ -4199,12 +4201,16 @@ export class UIRenderer {
                 const isTrackByArtist = (track) => {
                     if (track.artists && Array.isArray(track.artists)) {
                         return track.artists.some(
-                            (a) => a && a.name && a.name.toLowerCase() === artistNameLower
+                            (a) => a && ((artist.id && a.id === artist.id) || (a.name && a.name.toLowerCase() === artistNameLower))
                         );
                     }
                     if (track.artist) {
-                        const artistStr = typeof track.artist === 'string' ? track.artist : track.artist.name;
-                        if (artistStr && artistStr.toLowerCase() === artistNameLower) return true;
+                        if (typeof track.artist === 'object') {
+                            if (artist.id && track.artist.id === artist.id) return true;
+                            if (track.artist.name && track.artist.name.toLowerCase() === artistNameLower) return true;
+                        } else if (typeof track.artist === 'string') {
+                            if (track.artist.toLowerCase() === artistNameLower) return true;
+                        }
                     }
                     return false;
                 };
@@ -4285,18 +4291,27 @@ export class UIRenderer {
                                 const sourceSpan = document.createElement('span');
                                 sourceSpan.className = 'library-source';
 
+                                const labelSpan = document.createElement('span');
+                                labelSpan.className = 'library-source-label';
+                                labelSpan.textContent = '· Source:\u00a0';
+
+                                const linkSpan = document.createElement('span');
+                                linkSpan.className = 'library-source-link';
+
+                                sourceSpan.style.cursor = 'pointer';
+                                sourceSpan.appendChild(labelSpan);
+                                sourceSpan.appendChild(linkSpan);
+
                                 if (sources.length === 1) {
                                     const srcLabel = sources[0].label.length > 15 ? sources[0].label.slice(0, 15) + '…' : sources[0].label;
-                                    sourceSpan.innerHTML = `<span class="library-source-label">· Source:&nbsp;</span><span class="library-source-link">${srcLabel}</span>`;
-                                    sourceSpan.style.cursor = 'pointer';
+                                    linkSpan.textContent = srcLabel;
                                     sourceSpan.addEventListener('click', (e) => {
                                         e.preventDefault();
                                         e.stopPropagation();
                                         navigate(sources[0].href);
                                     });
                                 } else {
-                                    sourceSpan.innerHTML = `<span class="library-source-label">· Source:&nbsp;</span><span class="library-source-link">Multiple Playlists</span>`;
-                                    sourceSpan.style.cursor = 'pointer';
+                                    linkSpan.textContent = 'Multiple Playlists';
                                     sourceSpan.addEventListener('click', (e) => {
                                         e.preventDefault();
                                         e.stopPropagation();
@@ -4306,11 +4321,16 @@ export class UIRenderer {
                                         const cancelBtn = document.getElementById('goto-playlist-cancel');
                                         const overlay = modal.querySelector('.modal-overlay');
 
-                                        list.innerHTML = sources.map((s) =>
-                                            `<div class="modal-option" data-href="${s.href}">
-                                                <span>${s.label}</span>
-                                            </div>`
-                                        ).join('');
+                                        list.innerHTML = '';
+                                        sources.forEach((s) => {
+                                            const option = document.createElement('div');
+                                            option.className = 'modal-option';
+                                            option.dataset.href = s.href;
+                                            const span = document.createElement('span');
+                                            span.textContent = s.label;
+                                            option.appendChild(span);
+                                            list.appendChild(option);
+                                        });
 
                                         const closeModal = () => {
                                             modal.classList.remove('active');
@@ -4357,7 +4377,7 @@ export class UIRenderer {
 
                 // Initial load
                 refreshInLibrary().then(() => {
-                    inLibraryContainer.style.display = 'none';
+                    inLibraryContainer.hidden = true;
                 });
 
                 // Setup chevron toggle (once)
@@ -4365,8 +4385,9 @@ export class UIRenderer {
                 const chevron = document.getElementById('in-library-chevron');
                 if (toggle) {
                     toggle.onclick = () => {
-                        const isOpen = inLibraryContainer.style.display !== 'none';
-                        inLibraryContainer.style.display = isOpen ? 'none' : '';
+                        const isOpen = !inLibraryContainer.hidden;
+                        inLibraryContainer.hidden = isOpen;
+                        toggle.setAttribute('aria-expanded', String(!isOpen));
                         if (chevron) {
                             chevron.style.transform = isOpen ? 'rotate(0deg)' : 'rotate(90deg)';
                         }
@@ -4379,15 +4400,17 @@ export class UIRenderer {
                     clearTimeout(refreshTimeout);
                     refreshTimeout = setTimeout(() => refreshInLibrary(), 300);
                 };
-                window.addEventListener('favorites-changed', debouncedRefresh);
-                window.addEventListener('playlist-tracks-changed', debouncedRefresh);
 
-                // Cleanup listeners when navigating away
+                // Cleanup previous listeners before attaching new ones
                 const cleanupOnNav = () => {
                     window.removeEventListener('favorites-changed', debouncedRefresh);
                     window.removeEventListener('playlist-tracks-changed', debouncedRefresh);
                     window.removeEventListener('popstate', cleanupOnNav);
                 };
+                cleanupOnNav();
+
+                window.addEventListener('favorites-changed', debouncedRefresh);
+                window.addEventListener('playlist-tracks-changed', debouncedRefresh);
                 window.addEventListener('popstate', cleanupOnNav, { once: true });
             }
 

--- a/styles.css
+++ b/styles.css
@@ -1994,6 +1994,10 @@ input[type='search']::-webkit-search-cancel-button {
     gap: 2px var(--spacing-xl);
 }
 
+#artist-detail-in-library[hidden] {
+    display: none;
+}
+
 .library-source {
     color: var(--muted-foreground);
     font-size: inherit;
@@ -2365,8 +2369,8 @@ input[type='search']::-webkit-search-cancel-button {
     align-items: center;
     gap: 1rem;
     flex-wrap: wrap;
-    overflow-wrap: break-word;
-    word-break: break-word;
+    overflow-wrap: anywhere;
+    word-break: normal;
     min-width: 0;
 }
 


### PR DESCRIPTION
Show liked tracks and playlist tracks by the artist with source labels, collapsible chevron toggle, and real-time updates via favorites-changed and playlist-tracks-changed events.

### Description
I’ve been using Spotify for many years, and then I tried a bunch of other music streaming platforms like Tidal, YouTube Music, Deezer, and others. Only Spotify has a feature that I find really useful: going to an artist’s page and seeing the songs you’ve liked. When I’m looking for new songs and start playing radio stations or mixes, I sometimes come across artists that I feel like I’ve heard before. So I go to their artist page and see that I had a few of their songs in my “Liked” list. It’s super useful, but Spotify stops there—it doesn’t show, for example, the songs you have in your playlists. Here, I’ve implemented a similar feature but made it more comprehensive. If you’ve added an artist’s songs to your “likes” or any playlist, they’ll appear in that artist’s “in your library” section, making the search much more straightforward. Also, currently on Monochrome, we don’t have a way to filter songs by artist in our library or playlists, so this solves part of the problem.

Used AI for the CSS and understanding the codebase
<img width="2292" height="1194" alt="immagine" src="https://github.com/user-attachments/assets/bf20a36d-e3f9-455c-858d-04e8be60165b" />
<img width="2286" height="1060" alt="immagine" src="https://github.com/user-attachments/assets/49f03993-f5bf-4341-8cec-1a7fa3bc6bd3" />
Hover effect on source:
<img width="761" height="87" alt="immagine" src="https://github.com/user-attachments/assets/f9ded2ec-85a5-4176-941f-48f41201be2a" />

dialog opened on click if Multiple Playlists:
<img width="573" height="355" alt="immagine" src="https://github.com/user-attachments/assets/c78b0bd4-7c52-4f4d-a1cc-1e7694987538" />
If source is Liked Tracks or single playlist, the click will redirect you there directly

Fixed long names of artists that broke the page
<img width="2319" height="448" alt="immagine" src="https://github.com/user-attachments/assets/053db7e2-a3b9-4e1f-879c-c9a591cd37b3" />

And in the section "In Your Library" name/year/source try to stay ever visible
<img width="2259" height="230" alt="immagine" src="https://github.com/user-attachments/assets/2b0ec203-56b1-40c7-a618-20e7e2041fd4" />


### Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Style/UI update
- [ ] Docs only

### Checklist
- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.

---
*By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Go to Playlist" modal for playlist navigation
  * Introduced "In Your Library" section on artist pages displaying library tracks with source labels
  * Implemented real-time library view synchronization when favorites or playlists change

* **UI Improvements**
  * Enhanced text wrapping for long titles to prevent overflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->