### PR TITLE
feat: enable Tailscale access via vite preview allowedHosts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,10 +35,10 @@ export default defineConfig(({ mode }) => {
                 // allowedHosts: ['<your_tailscale_hostname>'], // e.g. pi5.tailf5f622.ts.net
             },
         },
-        // preview: {
-        //     host: true,
-        //     allowedHosts: ['<your_tailscale_hostname>'], // e.g. pi5.tailf5f622.ts.net
-        // },
+        preview: {
+            host: true,
+            allowedHosts: ['100.121.228.100'],
+        },
         build: {
             outDir: 'dist',
             emptyOutDir: true,


### PR DESCRIPTION
Uncomment and configure the preview host settings to allow access from Tailscale IP 100.121.228.100 (pi5).

https://claude.ai/code/session_017S5zsnw7m8eBmEEEM8gV7L

### Description
### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist
- [ ] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [ ] **I understand every line of code I am submitting.**
- [ ] I have tested these changes locally, and they work as expected.

---
*By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled preview server configuration with restricted host access to enhance security and deployment capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->