### PR TITLE
refactor(hifi): update localStorage and token handling

### DIFF
--- a/js/HiFi.ts
+++ b/js/HiFi.ts
@@ -18,8 +18,6 @@ export class TidalResponse extends Response {
     }
 }
 
-/** A container for the mock localStorage */
-
 export class HiFiClient {
     private static tokenPromise: Promise<string> | null = null;
     private static albumTracksMax = 20;
@@ -31,8 +29,7 @@ export class HiFiClient {
     private static _localStorage: Record<string, string> = {};
     private static get localStorage() {
         return (
-            globalThis?.localStorage ??
-            window?.localStorage ?? {
+            globalThis?.localStorage ?? {
                 getItem: (key) => HiFiClient._localStorage[key],
                 setItem: (key, value) => {
                     HiFiClient._localStorage[key] = String(value);
@@ -94,12 +91,17 @@ export class HiFiClient {
     }
 
     private static encodeBasic(id: string, secret: string) {
-        if (typeof window !== 'undefined' && typeof window.btoa === 'function') {
-            return window.btoa(`${id}:${secret}`);
+        if (typeof globalThis.btoa === 'function') {
+            return btoa(`${id}:${secret}`);
         }
         // Node fallback
         return Buffer.from(`${id}:${secret}`).toString('base64');
     }
+
+	static setToken(token: string, expiry: number = Date.now() + 60000) {
+		HiFiClient.token = token;
+		HiFiClient.appTokenExpiry = expiry
+	}
 
     private static async fetchAppToken(
         signal: AbortSignal = new AbortController().signal,
@@ -747,10 +749,6 @@ export class HiFiClient {
                         offset: qp.offset ? Number(qp.offset) : undefined,
                     });
                 default:
-                    // unknown local route => treat as raw upstream path (forward)
-                    if (pathOrUrl.startsWith('http')) {
-                        return await this.fetchJson(pathOrUrl);
-                    }
                     throw new Error(`Unknown route: ${pathname}`);
             }
         } catch (err) {


### PR DESCRIPTION
Modified token encoding to use globalThis and added a setToken method.

### Description
### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist
- [ ] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [ ] **I understand every line of code I am submitting.**
- [ ] I have tested these changes locally, and they work as expected.

---
*By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `setToken()` method to programmatically set OAuth authentication tokens with automatic expiry handling (60-second default).

* **Improvements**
  * Enhanced error handling for unrecognized API routes with explicit error messages.
  * Improved cross-environment compatibility for Base64 encoding and data storage mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->