### PR TITLE
fix(metadata): write xid to mp4 files

### DIFF
--- a/js/taglib.worker.ts
+++ b/js/taglib.worker.ts
@@ -122,6 +122,10 @@ export async function addMetadataToAudio(message: _AddMetadataMessage): Promise<
 
         if (copyright) props.replace('COPYRIGHT', [copyright]);
         if (isrc) props.replace('ISRC', [isrc]);
+        if (isrc && isMp4) {
+            const mp4Tag = (underlying as Mp4File).tag() as Mp4Tag;
+            mp4Tag.setItem('xid ', Mp4Item.fromStringList([`:isrc:${isrc}`]));
+        }
         if (lyrics) props.replace('LYRICS', [lyrics.replace(/\r/g, '').replace(/\n/g, '\r\n')]);
 
         if (explicit !== undefined) {


### PR DESCRIPTION
### Description
### Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist
- [ ] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [ ] **I understand every line of code I am submitting.**
- [ ] I have tested these changes locally, and they work as expected.

---
*By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * MP4 files now include ISRC (International Standard Recording Code) data in metadata when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->