### PR TITLE
feat(ui): redesign fullscreen visualizer controls and lyrics panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -4105,9 +4105,9 @@
                                 </div>
                                 <div class="setting-item">
                                     <div class="info">
-                                        <span class="label">Romaji Lyrics</span>
+                                        <span class="label">Inline Fullscreen Lyrics</span>
                                         <span class="description"
-                                            >Convert Japanese lyrics to Romaji (Latin characters)</span
+                                            >Display lyrics inline instead of the side panel in fullscreen mode</span
                                         >
                                     </div>
                                     <label class="toggle-switch">

--- a/js/settings.js
+++ b/js/settings.js
@@ -2318,6 +2318,15 @@ export async function initializeSettings(scrobbler, player, api, ui) {
         });
     }
 
+    // Fullscreen Lyrics Toggle
+    const fullscreenLyricsToggle = document.getElementById('fullscreen-lyrics-toggle');
+    if (fullscreenLyricsToggle) {
+        fullscreenLyricsToggle.checked = lyricsSettings.isFullscreenLyricsEnabled();
+        fullscreenLyricsToggle.addEventListener('change', (e) => {
+            lyricsSettings.setFullscreenLyrics(e.target.checked);
+        });
+    }
+
     // Download Lyrics Toggle
     const downloadLyricsToggle = document.getElementById('download-lyrics-toggle');
     if (downloadLyricsToggle) {

--- a/js/storage.js
+++ b/js/storage.js
@@ -526,6 +526,7 @@ export const fullscreenCoverClickSettings = {
 
 export const lyricsSettings = {
     DOWNLOAD_WITH_TRACKS: 'lyrics-download-with-tracks',
+    FULLSCREEN_LYRICS: 'fullscreen-lyrics-enabled',
 
     shouldDownloadLyrics() {
         try {
@@ -537,6 +538,14 @@ export const lyricsSettings = {
 
     setDownloadLyrics(enabled) {
         localStorage.setItem(this.DOWNLOAD_WITH_TRACKS, enabled ? 'true' : 'false');
+    },
+
+    isFullscreenLyricsEnabled() {
+        return localStorage.getItem(this.FULLSCREEN_LYRICS) === 'true';
+    },
+
+    setFullscreenLyrics(enabled) {
+        localStorage.setItem(this.FULLSCREEN_LYRICS, enabled ? 'true' : 'false');
     },
 };
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -26,6 +26,7 @@ import {
     fontSettings,
     contentBlockingSettings,
     settingsUiState,
+    lyricsSettings,
 } from './storage.js';
 import { db } from './db.js';
 import { getVibrantColorFromImage } from './vibrant-color.js';
@@ -1127,6 +1128,7 @@ export class UIRenderer {
 
         this.setupFullscreenControls();
 
+        overlay.classList.toggle('inline-lyrics', lyricsSettings.isFullscreenLyricsEnabled());
         overlay.style.display = 'flex';
 
         const startVisualizer = async () => {
@@ -1182,7 +1184,7 @@ export class UIRenderer {
     closeFullscreenCover() {
         const overlay = document.getElementById('fullscreen-cover-overlay');
         overlay.style.display = 'none';
-        overlay.classList.remove('visualizer-active', 'ui-hidden', 'controls-idle');
+        overlay.classList.remove('visualizer-active', 'ui-hidden', 'controls-idle', 'inline-lyrics');
 
         const playerBar = document.querySelector('.now-playing-bar');
         if (playerBar) playerBar.style.removeProperty('display');

--- a/styles.css
+++ b/styles.css
@@ -3978,7 +3978,7 @@ input:checked + .slider::before {
     pointer-events: none;
 }
 
-body:has(#fullscreen-cover-overlay.ui-hidden) #side-panel[data-view='lyrics'] {
+body:has(#fullscreen-cover-overlay.ui-hidden.inline-lyrics) #side-panel[data-view='lyrics'] {
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.5s ease;
@@ -7314,8 +7314,8 @@ body:has(#fullscreen-cover-overlay:not([style*='display: none'])) .now-playing-b
     }
 }
 
-/* Side panel in fullscreen lyrics mode */
-body:has(#fullscreen-cover-overlay[style*='flex']) #side-panel[data-view='lyrics'] {
+/* Inline lyrics mode in fullscreen */
+body:has(#fullscreen-cover-overlay.inline-lyrics[style*='flex']) #side-panel[data-view='lyrics'] {
     background: transparent;
     backdrop-filter: none;
     border-left: none;
@@ -7324,23 +7324,23 @@ body:has(#fullscreen-cover-overlay[style*='flex']) #side-panel[data-view='lyrics
     max-width: 50%;
 }
 
-body:has(#fullscreen-cover-overlay[style*='flex']) #side-panel[data-view='lyrics'] .panel-header {
+body:has(#fullscreen-cover-overlay.inline-lyrics[style*='flex']) #side-panel[data-view='lyrics'] .panel-header {
     display: none;
 }
 
-body:has(#fullscreen-cover-overlay[style*='flex']) #side-panel[data-view='lyrics'] .panel-content {
+body:has(#fullscreen-cover-overlay.inline-lyrics[style*='flex']) #side-panel[data-view='lyrics'] .panel-content {
     padding: 6rem 3rem 4rem;
     mask-image: linear-gradient(to bottom, transparent, black 5%, black 85%, transparent);
 }
 
-body:has(#fullscreen-cover-overlay[style*='flex']) #side-panel[data-view='lyrics'] .synced-line {
+body:has(#fullscreen-cover-overlay.inline-lyrics[style*='flex']) #side-panel[data-view='lyrics'] .synced-line {
     font-size: 1.75rem;
     line-height: 1.6;
     padding: 0.6rem 0;
     text-shadow: 0 2px 12px rgb(0, 0, 0, 0.8);
 }
 
-body:has(#fullscreen-cover-overlay[style*='flex']) #side-panel[data-view='lyrics'] .synced-line.active {
+body:has(#fullscreen-cover-overlay.inline-lyrics[style*='flex']) #side-panel[data-view='lyrics'] .synced-line.active {
     font-size: 2rem;
     font-weight: 700;
     color: var(--foreground);
@@ -7349,24 +7349,45 @@ body:has(#fullscreen-cover-overlay[style*='flex']) #side-panel[data-view='lyrics
         0 0 40px rgb(0, 0, 0, 0.5);
 }
 
-/* Fullscreen layout shift when lyrics panel is active */
-body:has(#side-panel.active[data-view='lyrics']) .fullscreen-main-view {
+/* Inline lyrics layout shift */
+body:has(#side-panel.active[data-view='lyrics']):has(#fullscreen-cover-overlay.inline-lyrics) .fullscreen-main-view {
     transition:
         flex 0.3s ease,
         padding-right 0.3s ease;
     padding-right: 50%;
 }
 
-body:has(#side-panel.active[data-view='lyrics']) .fullscreen-lyrics-toggle {
+body:has(#side-panel.active[data-view='lyrics']):has(#fullscreen-cover-overlay.inline-lyrics)
+    .fullscreen-lyrics-toggle {
     right: calc(50% + 4.5rem);
 }
 
-body:has(#side-panel.active[data-view='lyrics']) #close-fullscreen-cover-btn {
+body:has(#side-panel.active[data-view='lyrics']):has(#fullscreen-cover-overlay.inline-lyrics)
+    #close-fullscreen-cover-btn {
     right: calc(50% + 1rem);
 }
 
-body:has(#side-panel.active[data-view='lyrics']) #toggle-ui-btn {
+body:has(#side-panel.active[data-view='lyrics']):has(#fullscreen-cover-overlay.inline-lyrics) #toggle-ui-btn {
     right: calc(50% + 8rem);
+}
+
+/* Side panel lyrics layout shift (non-inline) */
+body:has(#side-panel.active[data-view='lyrics']):has(#fullscreen-cover-overlay:not(.inline-lyrics))
+    .fullscreen-main-view {
+    transition:
+        flex 0.3s ease,
+        padding-right 0.3s ease;
+    padding-right: 600px;
+}
+
+body:has(#side-panel.active[data-view='lyrics']):has(#fullscreen-cover-overlay:not(.inline-lyrics))
+    .fullscreen-lyrics-toggle {
+    right: calc(600px + 4.5rem);
+}
+
+body:has(#side-panel.active[data-view='lyrics']):has(#fullscreen-cover-overlay:not(.inline-lyrics))
+    #close-fullscreen-cover-btn {
+    right: calc(600px + 1rem);
 }
 
 /* Fullscreen layout shift when queue panel is active */
@@ -7386,21 +7407,27 @@ body:has(#side-panel.active[data-view='queue']) #close-fullscreen-cover-btn {
 }
 
 @media (max-width: 1200px) {
-    body:has(#side-panel.active[data-view='queue']) .fullscreen-main-view {
+    body:has(#side-panel.active[data-view='queue']) .fullscreen-main-view,
+    body:has(#side-panel.active[data-view='lyrics']):has(#fullscreen-cover-overlay:not(.inline-lyrics))
+        .fullscreen-main-view {
         padding-right: 50vw;
     }
 
-    body:has(#side-panel.active[data-view='queue']) .fullscreen-lyrics-toggle {
+    body:has(#side-panel.active[data-view='queue']) .fullscreen-lyrics-toggle,
+    body:has(#side-panel.active[data-view='lyrics']):has(#fullscreen-cover-overlay:not(.inline-lyrics))
+        .fullscreen-lyrics-toggle {
         right: calc(50vw + 4.5rem);
     }
 
-    body:has(#side-panel.active[data-view='queue']) #close-fullscreen-cover-btn {
+    body:has(#side-panel.active[data-view='queue']) #close-fullscreen-cover-btn,
+    body:has(#side-panel.active[data-view='lyrics']):has(#fullscreen-cover-overlay:not(.inline-lyrics))
+        #close-fullscreen-cover-btn {
         right: calc(50vw + 1rem);
     }
 }
 
 @media (max-width: 768px) {
-    body:has(#fullscreen-cover-overlay[style*='flex']) #side-panel[data-view='lyrics'] {
+    body:has(#fullscreen-cover-overlay.inline-lyrics[style*='flex']) #side-panel[data-view='lyrics'] {
         width: 100vw;
         max-width: 100vw;
     }


### PR DESCRIPTION
### Description

Redesigns the fullscreen visualizer UI to feel more like Apple Music's fullscreen player.

- Controls auto-hide after inactivity and reappear on mouse move
- Lyrics display inline next to album art instead of in a separate panel
- Consistent button styling and text shadows for readability over busy visualizers

### Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Style/UI update
- [ ] Docs only

### Checklist

- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._