### PR TITLE
HOTFIX: Fix track validation in loveTrack method

### DIFF
--- a/js/listenbrainz.js
+++ b/js/listenbrainz.js
@@ -249,7 +249,7 @@ export class ListenBrainzScrobbler {
     }
 
     async loveTrack(track) {
-        if (!track.artist?.name || track.title) return;
+        if (!track.artist?.name || !track.title) return;
         const trackKey = `${track.artist.name}-${track.title}`;
         if (!this.isEnabled() || this.lovingTracks.has(trackKey)) return;
         this.lovingTracks.add(trackKey);


### PR DESCRIPTION
### Description
super dumb mistake i forgot about ! to make sure that track.title is here

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist

- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected. YES IT WORKING NOW
- [ ] Is this Pull request Using AI/Is Vibecoded?

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed input validation for the track favoriting feature to properly verify that both artist name and track title information are present before executing the tracking logic. This ensures the feature functions correctly when complete metadata is available, improving reliability of track favorite submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->