### PR TITLE
fix(library): share playlist with the correct url

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -1641,7 +1641,8 @@ export async function handleTrackAction(
         // Use stored href from card if available, otherwise construct URL
         const contextMenu = document.getElementById('context-menu');
         const storedHref = contextMenu?._contextHref;
-        const url = getShareUrl(storedHref ? storedHref : `/${type}/${item.id || item.uuid}`);
+        const typeForUrl= type === 'user-playlist' ? 'userplaylist' : type;
+        const url = getShareUrl(storedHref ? storedHref : `/${typeForUrl}/${item.id || item.uuid}`);
 
         trackCopyLink(type, item.id || item.uuid);
         navigator.clipboard.writeText(url).then(() => {


### PR DESCRIPTION
### Description

Fixes an issue where playlist links copied from the library cover's three-dot menu would not work due to an incorrect URL format being generated.

The type variable passed to the URL getter function was inconsistent, causing the generated link to include user-playlist instead of the expected userplaylist path. As a result, links copied from the library failed to resolve correctly, while links copied directly from the playlist page worked as intended.

Fixes #421 

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist

- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.
- [x] Is this Pull request Using AI/Is Vibecoded?

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed share URL generation for user playlists to use the correct format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->