### PR TITLE
fix(downloads): applyAudioPostProcessing now uses lookup audio quality to determine if the available track is lossless

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -1883,7 +1883,7 @@ export class LosslessAPI {
                     quality,
                     onProgress,
                     options.signal,
-                    track?.audioQuality ?? null
+                    lookup.info?.audioQuality ?? null
                 );
             }
 


### PR DESCRIPTION
### Description

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist

- [ ] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [ ] **I understand every line of code I am submitting.**
- [ ] I have tested these changes locally, and they work as expected.

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio-quality handling for track downloads: post-processing now uses a more reliable source of audio-quality metadata for non-video downloads, reducing incorrect or missing quality information and ensuring downloaded tracks are processed with the intended audio settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->