### PR TITLE
fix(downloads): pass DOLBY_ATMOS to applyAudioPostProcessing if track…

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -1751,6 +1751,7 @@ export class LosslessAPI {
 
             const { lookup, enrichedTrack, isVideo } = await this.enrichTrack(track, { downloadQuality });
 
+            let postProcessingQuality = lookup.info?.audioQuality ?? null;
             let streamUrl;
             let blob;
 
@@ -1783,6 +1784,10 @@ export class LosslessAPI {
                         const manifest = await fetch(stream.url, { signal: options.signal });
                         const manifestText = await manifest.text();
                         streamUrl = this.extractStreamUrlFromManifest(btoa(manifestText));
+
+                        if (streamUrl) {
+                            postProcessingQuality = 'DOLBY_ATMOS';
+                        }
                     } catch (err) {
                         console.error('Failed to extract Dolby Atmos stream URL:', err);
                     }
@@ -1883,7 +1888,7 @@ export class LosslessAPI {
                     quality,
                     onProgress,
                     options.signal,
-                    lookup.info?.audioQuality ?? null
+                    postProcessingQuality
                 );
             }
 


### PR DESCRIPTION
… is atmos

### Description

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist

- [ ] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [ ] **I understand every line of code I am submitting.**
- [ ] I have tested these changes locally, and they work as expected.
- [ ] Is this Pull request Using AI/Is Vibecoded?

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced audio quality handling for Dolby Atmos tracks. When downloading a track with Dolby Atmos enabled and available, audio post-processing quality is now properly optimized to leverage Dolby Atmos capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->