### PR TITLE
fix(downloads): change FLAC ffmpegArgs to use 'copy' codec

### DIFF
--- a/js/ffmpegFormats.ts
+++ b/js/ffmpegFormats.ts
@@ -151,7 +151,7 @@ if (import.meta.env.DEV) {
 export const containerFormats: Record<string, ContainerFormat> = {
     flac: {
         displayName: 'FLAC',
-        ffmpegArgs: ['-vn', '-map_metadata', '-1', '-map', '0:a', '-c:a', 'flac'],
+        ffmpegArgs: ['-vn', '-map_metadata', '-1', '-map', '0:a', '-c:a', 'copy'],
         outputFilename: 'output.flac',
         outputMime: 'audio/flac',
         extension: 'flac',


### PR DESCRIPTION
### Description

### Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist

- [ ] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [ ] **I understand every line of code I am submitting.**
- [ ] I have tested these changes locally, and they work as expected.
- [ ] Is this Pull request Using AI/Is Vibecoded?

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FLAC audio processing by optimizing codec behavior to use stream copying rather than full re-encoding. This change significantly reduces CPU and memory consumption, processing time, and system resource usage while preserving full audio quality. Users can expect faster FLAC file operations and noticeably improved overall system performance and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->