### PR TITLE
fix: disambiguate same-name artists in search results

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -747,7 +747,7 @@ export class UIRenderer {
             id: artist.id,
             href: `/artist/${artist.id}`,
             title: escapeHtml(artist.name),
-            subtitle: '',
+            subtitle: [artist.type || 'Artist', artist.popularity ? `${artist.popularity}% popularity` : ''].filter(Boolean).join(' • '),
             imageHTML: `<img src="${this.api.getArtistPictureUrl(artist.picture)}" alt="${escapeHtml(artist.name)}" class="card-image" loading="lazy">`,
             actionButtonsHTML: `
                 <button class="like-btn card-like-btn" data-action="toggle-like" data-type="artist" title="Add to Liked">
@@ -2879,6 +2879,7 @@ export class UIRenderer {
                 });
             }
 
+            finalArtists.sort((a, b) => (b.popularity || 0) - (a.popularity || 0));
             artistsContainer.innerHTML = finalArtists.length
                 ? finalArtists.map((artist) => this.createArtistCardHTML(artist)).join('')
                 : createPlaceholder('No artists found.');


### PR DESCRIPTION
### Description

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist

- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.
- [ ] Is this Pull request Using AI/Is Vibecoded?


<img width="1702" height="884" alt="Captura de pantalla 2026-04-03 015422" src="https://github.com/user-attachments/assets/40f40042-ee1f-4442-b514-e5855910d3ef" />


---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Artist cards now display artist type and popularity percentage.
  * Search results are sorted by popularity, with higher-rated artists appearing first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->