### PR TITLE
fix: filter albums and tracks by artist ID to prevent showing wrong same-name artists

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -1077,18 +1077,20 @@ export class LosslessAPI {
         entries.forEach((entry) => scan(entry, visited));
         scan(primaryData, visited);
 
-        const numericArtistId = Number(artistId);
+        const matchesArtistId = (item) => {
+            const candidateIds = [
+                item.artist?.id,
+                ...(Array.isArray(item.artists) ? item.artists.map((a) => a.id) : []),
+            ].filter((id) => id != null);
+            return candidateIds.some((id) => Number(id) === Number(artistId));
+        };
+
         if (!options.lightweight) {
             try {
                 const videoSearch = await this.searchVideos(artist.name);
                 if (videoSearch && videoSearch.items) {
                     for (const item of videoSearch.items) {
-                        const itemArtistId = item.artist?.id;
-                        const matchesArtist =
-                            itemArtistId === numericArtistId ||
-                            (Array.isArray(item.artists) && item.artists.some((a) => a.id === numericArtistId));
-
-                        if (matchesArtist && !videoMap.has(item.id)) {
+                        if (matchesArtistId(item) && !videoMap.has(item.id)) {
                             videoMap.set(item.id, item);
                         }
                     }
@@ -1098,11 +1100,7 @@ export class LosslessAPI {
             }
         }
 
-        const rawReleases = Array.from(albumMap.values()).filter((album) => {
-            const albumArtistId = album.artist?.id;
-            return albumArtistId === numericArtistId ||
-                (Array.isArray(album.artists) && album.artists.some((a) => a.id === numericArtistId));
-        });
+        const rawReleases = Array.from(albumMap.values()).filter(matchesArtistId);
         const allReleases = this.deduplicateAlbums(rawReleases).sort(
             (a, b) => new Date(b.releaseDate || 0) - new Date(a.releaseDate || 0)
         );
@@ -1111,11 +1109,7 @@ export class LosslessAPI {
         const albums = allReleases.filter((a) => !eps.includes(a));
 
         const topTracks = Array.from(trackMap.values())
-            .filter((track) => {
-                const trackArtistId = track.artist?.id;
-                return trackArtistId === numericArtistId ||
-                    (Array.isArray(track.artists) && track.artists.some((a) => a.id === numericArtistId));
-            })
+            .filter(matchesArtistId)
             .sort((a, b) => (b.popularity || 0) - (a.popularity || 0))
             .slice(0, 15);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artist filtering so search results show only releases, top tracks, and related video matches for the selected artist, removing unrelated content and improving result accuracy and relevance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->