### PR TITLE
Handle NaN in numeric settings parsing

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -1137,7 +1137,8 @@ export async function initializeSettings(scrobbler, player, api, ui) {
     if (replayGainPreamp) {
         replayGainPreamp.value = replayGainSettings.getPreamp();
         replayGainPreamp.addEventListener('change', (e) => {
-            replayGainSettings.setPreamp(parseFloat(e.target.value) || 3);
+            const val = parseFloat(e.target.value);
+            replayGainSettings.setPreamp(isNaN(val) ? 3 : val);
             player.applyReplayGain();
         });
     }
@@ -1174,7 +1175,8 @@ export async function initializeSettings(scrobbler, player, api, ui) {
     if (playbackSpeedSlider && playbackSpeedInput) {
         // Helper function to update both controls
         const updatePlaybackSpeedControls = (speed) => {
-            const validSpeed = Math.max(0.01, Math.min(100, parseFloat(speed) || 1.0));
+            const parsedSpeed = parseFloat(speed);
+            const validSpeed = Math.max(0.01, Math.min(100, isNaN(parsedSpeed) ? 1.0 : parsedSpeed));
             playbackSpeedInput.value = validSpeed;
             // Only update slider if value is within slider range
             if (validSpeed >= 0.25 && validSpeed <= 4.0) {

--- a/js/storage.js
+++ b/js/storage.js
@@ -442,7 +442,8 @@ export const lastFMStorage = {
     },
 
     setScrobblePercentage(percentage) {
-        const validPercentage = Math.max(1, Math.min(100, parseInt(percentage, 10) || 75));
+        const parsed = parseInt(percentage, 10);
+        const validPercentage = Math.max(1, Math.min(100, isNaN(parsed) ? 75 : parsed));
         localStorage.setItem(this.SCROBBLE_PERCENTAGE_KEY, validPercentage.toString());
     },
 
@@ -1123,9 +1124,10 @@ export const equalizerSettings = {
     },
 
     setBandCount(count) {
+        const parsedCount = parseInt(count, 10);
         const validCount = Math.max(
             this.MIN_BANDS,
-            Math.min(this.MAX_BANDS, parseInt(count, 10) || this.DEFAULT_BAND_COUNT)
+            Math.min(this.MAX_BANDS, isNaN(parsedCount) ? this.DEFAULT_BAND_COUNT : parsedCount)
         );
         localStorage.setItem(this.BAND_COUNT_KEY, validCount.toString());
     },
@@ -2451,7 +2453,8 @@ export const fontSettings = {
     },
 
     setFontSize(size) {
-        const validSize = Math.max(50, Math.min(200, parseInt(size, 10) || 100));
+        const parsed = parseInt(size, 10);
+        const validSize = Math.max(50, Math.min(200, isNaN(parsed) ? 100 : parsed));
         localStorage.setItem(this.FONT_SIZE_KEY, validSize.toString());
         this.applyFontSize();
         return validSize;


### PR DESCRIPTION
Replace usages of parseFloat(... ) || default and parseInt(... ) || default with explicit parse + isNaN checks to avoid treating valid numeric zeros as falsy. Changes in js/settings.js and js/storage.js update parsing for replayGain preamp, playback speed, scrobble percentage, equalizer band count, and font size so only NaN triggers the fallback value and valid 0 values are preserved.

### Description

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist

- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.
- [ ] Is this Pull request Using AI/Is Vibecoded?

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved input validation for ReplayGain preamp, playback speed, and storage settings (scrobble percentage, equalizer band count, font size) to better handle non-numeric values and ensure proper fallback to defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->