### PR TITLE
Fix audio effects not working on iOS Safari

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -1478,7 +1478,8 @@ export class LosslessAPI {
         let isUsingManifestEndpoint = false;
 
         try {
-            const manifestType = isIos || isSafari ? 'HLS' : 'MPEG_DASH';
+            const hasMSE = typeof window !== 'undefined' && (!!window.MediaSource || !!window.ManagedMediaSource);
+            const manifestType = (!hasMSE && (isIos || isSafari)) ? 'HLS' : 'MPEG_DASH';
             const isApple = isIos || isSafari;
 
             let canPlayAtmos = false;

--- a/js/audio-context.js
+++ b/js/audio-context.js
@@ -475,8 +475,8 @@ class AudioContextManager {
 
         this.audio = audioElement;
 
-        if (isIos) {
-            console.log('[AudioContext] Skipping Web Audio initialization on iOS for lock screen compatibility');
+        if (isIos && !window.MediaSource && !window.ManagedMediaSource) {
+            console.log('[AudioContext] Skipping Web Audio on iOS without MSE support');
             return;
         }
 
@@ -772,7 +772,7 @@ class AudioContextManager {
 
         console.log('[AudioContext] Current state:', this.audioContext.state);
 
-        if (this.audioContext.state === 'suspended') {
+        if (this.audioContext.state === 'suspended' || this.audioContext.state === 'interrupted') {
             try {
                 await this.audioContext.resume();
                 console.log('[AudioContext] Resumed successfully, state:', this.audioContext.state);

--- a/js/player.js
+++ b/js/player.js
@@ -257,18 +257,10 @@ export class Player {
         const el = this.activeElement;
 
         // Apply to audio element and/or Web Audio graph
-        const isApple = isIos || isSafari;
-
-        if (audioContextManager.isReady() && !isApple) {
-            // If Web Audio is active, we apply volume there for better compatibility
-            // Especially on Linux where audio.volume might not affect the Web Audio graph
+        if (audioContextManager.isReady()) {
             el.volume = 1.0;
             audioContextManager.setVolume(effectiveVolume);
         } else {
-            // Safari bypasses WebAudio for HLS, so we MUST set el.volume directly to reflect ReplayGain
-            if (audioContextManager.isReady()) {
-                audioContextManager.setVolume(1.0); // Reset graph gain if it somehow routes
-            }
             el.volume = Math.max(0, Math.min(1, effectiveVolume));
         }
     }


### PR DESCRIPTION
Web Audio API was completely disabled on iOS via a blanket guard for lock screen compatibility. Modern iOS (17+) supports ManagedMediaSource and MediaSession API, making it safe to enable Web Audio.

Three changes:

1. audio-context.js: Replace blanket isIos guard with MSE capability check so Web Audio initializes on iOS 17+ (which has ManagedMediaSource). Also handle 'interrupted' state in resume() for iOS audio session interruptions.

2. player.js: Remove the isApple volume routing bypass in applyReplayGain(). When Web Audio is active, volume routes through the gain node regardless of platform, ensuring EQ/DSP effects are properly gain-staged.

3. api.js: Use DASH manifest type on Safari/iOS when MSE is available. Safari's native HLS decoder bypasses createMediaElementSource(), so audio effects had no effect. DASH playback goes through Shaka Player (which uses MSE/ManagedMediaSource), properly routing audio through the Web Audio processing graph.

### Description

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist

- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [ ] I have tested these changes locally, and they work as expected.
- [ ] Is this Pull request Using AI/Is Vibecoded?

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio resumption handling on iOS when audio context is interrupted or suspended.
  * Enhanced stream format selection to prioritize MPEG_DASH when Media Source Extensions are available, improving compatibility.
  * Simplified volume control behavior for Apple devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->