### PR TITLE
Fix audio effects on iOS Safari and improve routing tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -4174,8 +4174,71 @@
                                 </div>
 
                                 <div class="binaural-dsp-container" id="binaural-dsp-container" style="display: none">
-                                    <div class="binaural-status" id="binaural-status">
-                                        <span class="binaural-mode-label">Mode: Stereo</span>
+                                    <div class="binaural-header-row">
+                                        <div class="binaural-status" id="binaural-status">
+                                            <span class="binaural-mode-label">Mode: Stereo</span>
+                                        </div>
+                                        <button class="eq-howto-btn" id="binaural-howto-btn" title="How to use">?</button>
+                                    </div>
+
+                                    <div class="eq-howto-panel" id="binaural-howto-panel" style="display: none">
+                                        <button class="eq-howto-close" id="binaural-howto-close" aria-label="Close tutorial">
+                                            &times;
+                                        </button>
+
+                                        <div class="eq-howto-tab">
+                                            <h4>Binaural / Spatial DSP - How to Use</h4>
+                                            <ol>
+                                                <li>
+                                                    <b>Enable Binaural DSP</b> with the main toggle. The system
+                                                    auto-detects whether your content is stereo or multichannel
+                                                    (5.1/7.1/Atmos) and switches mode accordingly.
+                                                </li>
+                                                <li>
+                                                    <b>Crossfeed</b> blends a filtered, delayed copy of each channel
+                                                    into the opposite ear - simulating speakers in a room instead of
+                                                    hard-panned headphone separation.
+                                                </li>
+                                                <li>
+                                                    Pick a <b>Crossfeed Level</b>: <b>Low</b> for a subtle blend,
+                                                    <b>Medium</b> (default) for natural speaker feel, <b>High</b> for
+                                                    a more blended, mono-like presentation.
+                                                </li>
+                                                <li>
+                                                    <b>HRTF Preset</b> controls virtual speaker angle for multichannel
+                                                    content: <b>Intimate</b> (&plusmn;22&deg;) places speakers close,
+                                                    <b>Studio</b> (&plusmn;30&deg;) mimics a mix room,
+                                                    <b>Wide</b> (&plusmn;45&deg;) gives an expansive soundstage.
+                                                </li>
+                                                <li>
+                                                    <b>Stereo Width</b> adjusts the spatial image using Mid/Side
+                                                    processing. Drag the <b>Width Amount</b> slider:
+                                                    <b>0</b> = full mono, <b>1.0</b> = unaltered, <b>2.0</b> = extra
+                                                    wide.
+                                                </li>
+                                                <li>
+                                                    <b>Auto-enable for Spatial Audio</b> automatically activates HRTF
+                                                    rendering when Atmos or multichannel content is detected - no
+                                                    manual switching needed.
+                                                </li>
+                                            </ol>
+                                            <p class="eq-howto-tip">
+                                                Tip: Crossfeed reduces listening fatigue on headphones during long
+                                                sessions. Start with <b>Medium</b> and adjust to taste.
+                                            </p>
+                                            <p class="eq-howto-tip">
+                                                Tip: For multichannel content (Atmos, 5.1, 7.1), the HRTF engine
+                                                synthesizes head-related transfer functions per channel - including
+                                                interaural time &amp; level differences and pinna coloring - so
+                                                spatial cues translate naturally to headphones.
+                                            </p>
+                                            <p class="eq-howto-tip">
+                                                Tip: Width below 1.0 narrows the stereo image (useful for poorly
+                                                mixed tracks). Width above 1.0 widens it - but going too far can
+                                                cause phase issues. Stay around <b>1.1-1.4</b> for a subtle
+                                                enhancement.
+                                            </p>
+                                        </div>
                                     </div>
 
                                     <div class="binaural-sub-setting">

--- a/index.html
+++ b/index.html
@@ -4174,13 +4174,9 @@
                                 </div>
 
                                 <div class="binaural-dsp-container" id="binaural-dsp-container" style="display: none">
-                                    <div class="binaural-header-row">
-                                        <div class="binaural-status" id="binaural-status">
-                                            <span class="binaural-mode-label">Mode: Stereo</span>
-                                        </div>
-                                        <button class="eq-howto-btn" id="binaural-howto-btn" title="How to use">
-                                            ?
-                                        </button>
+                                    <div class="binaural-status" id="binaural-status">
+                                        <span class="binaural-mode-label">Mode: Stereo</span>
+                                        <button class="eq-howto-btn" id="binaural-howto-btn" title="How to use">?</button>
                                     </div>
 
                                     <div class="eq-howto-panel" id="binaural-howto-panel" style="display: none">

--- a/index.html
+++ b/index.html
@@ -4178,11 +4178,17 @@
                                         <div class="binaural-status" id="binaural-status">
                                             <span class="binaural-mode-label">Mode: Stereo</span>
                                         </div>
-                                        <button class="eq-howto-btn" id="binaural-howto-btn" title="How to use">?</button>
+                                        <button class="eq-howto-btn" id="binaural-howto-btn" title="How to use">
+                                            ?
+                                        </button>
                                     </div>
 
                                     <div class="eq-howto-panel" id="binaural-howto-panel" style="display: none">
-                                        <button class="eq-howto-close" id="binaural-howto-close" aria-label="Close tutorial">
+                                        <button
+                                            class="eq-howto-close"
+                                            id="binaural-howto-close"
+                                            aria-label="Close tutorial"
+                                        >
                                             &times;
                                         </button>
 
@@ -4201,8 +4207,8 @@
                                                 </li>
                                                 <li>
                                                     Pick a <b>Crossfeed Level</b>: <b>Low</b> for a subtle blend,
-                                                    <b>Medium</b> (default) for natural speaker feel, <b>High</b> for
-                                                    a more blended, mono-like presentation.
+                                                    <b>Medium</b> (default) for natural speaker feel, <b>High</b> for a
+                                                    more blended, mono-like presentation.
                                                 </li>
                                                 <li>
                                                     <b>HRTF Preset</b> controls virtual speaker angle for multichannel
@@ -4212,14 +4218,13 @@
                                                 </li>
                                                 <li>
                                                     <b>Stereo Width</b> adjusts the spatial image using Mid/Side
-                                                    processing. Drag the <b>Width Amount</b> slider:
-                                                    <b>0</b> = full mono, <b>1.0</b> = unaltered, <b>2.0</b> = extra
-                                                    wide.
+                                                    processing. Drag the <b>Width Amount</b> slider: <b>0</b> = full
+                                                    mono, <b>1.0</b> = unaltered, <b>2.0</b> = extra wide.
                                                 </li>
                                                 <li>
                                                     <b>Auto-enable for Spatial Audio</b> automatically activates HRTF
-                                                    rendering when Atmos or multichannel content is detected - no
-                                                    manual switching needed.
+                                                    rendering when Atmos or multichannel content is detected - no manual
+                                                    switching needed.
                                                 </li>
                                             </ol>
                                             <p class="eq-howto-tip">
@@ -4229,14 +4234,13 @@
                                             <p class="eq-howto-tip">
                                                 Tip: For multichannel content (Atmos, 5.1, 7.1), the HRTF engine
                                                 synthesizes head-related transfer functions per channel - including
-                                                interaural time &amp; level differences and pinna coloring - so
-                                                spatial cues translate naturally to headphones.
+                                                interaural time &amp; level differences and pinna coloring - so spatial
+                                                cues translate naturally to headphones.
                                             </p>
                                             <p class="eq-howto-tip">
-                                                Tip: Width below 1.0 narrows the stereo image (useful for poorly
-                                                mixed tracks). Width above 1.0 widens it - but going too far can
-                                                cause phase issues. Stay around <b>1.1-1.4</b> for a subtle
-                                                enhancement.
+                                                Tip: Width below 1.0 narrows the stereo image (useful for poorly mixed
+                                                tracks). Width above 1.0 widens it - but going too far can cause phase
+                                                issues. Stay around <b>1.1-1.4</b> for a subtle enhancement.
                                             </p>
                                         </div>
                                     </div>

--- a/index.html
+++ b/index.html
@@ -4176,7 +4176,9 @@
                                 <div class="binaural-dsp-container" id="binaural-dsp-container" style="display: none">
                                     <div class="binaural-status" id="binaural-status">
                                         <span class="binaural-mode-label">Mode: Stereo</span>
-                                        <button class="eq-howto-btn" id="binaural-howto-btn" title="How to use">?</button>
+                                        <button class="eq-howto-btn" id="binaural-howto-btn" title="How to use">
+                                            ?
+                                        </button>
                                     </div>
 
                                     <div class="eq-howto-panel" id="binaural-howto-panel" style="display: none">

--- a/js/api.js
+++ b/js/api.js
@@ -1478,7 +1478,8 @@ export class LosslessAPI {
         let isUsingManifestEndpoint = false;
 
         try {
-            const manifestType = isIos || isSafari ? 'HLS' : 'MPEG_DASH';
+            const hasMSE = typeof window !== 'undefined' && (!!window.MediaSource || !!window.ManagedMediaSource);
+            const manifestType = (!hasMSE && (isIos || isSafari)) ? 'HLS' : 'MPEG_DASH';
             const isApple = isIos || isSafari;
 
             let canPlayAtmos = false;

--- a/js/api.js
+++ b/js/api.js
@@ -1479,7 +1479,7 @@ export class LosslessAPI {
 
         try {
             const hasMSE = typeof window !== 'undefined' && (!!window.MediaSource || !!window.ManagedMediaSource);
-            const manifestType = (!hasMSE && (isIos || isSafari)) ? 'HLS' : 'MPEG_DASH';
+            const manifestType = !hasMSE && (isIos || isSafari) ? 'HLS' : 'MPEG_DASH';
             const isApple = isIos || isSafari;
 
             let canPlayAtmos = false;

--- a/js/audio-context.js
+++ b/js/audio-context.js
@@ -2,7 +2,7 @@
 // Shared Audio Context Manager - handles EQ and provides context for visualizer
 // Supports 3-32 parametric EQ bands
 
-import { isIos } from './platform-detection.js';
+import { isIos, isSafari } from './platform-detection.js';
 import { equalizerSettings, monoAudioSettings, binauralDspSettings } from './storage.js';
 import { BinauralDSP } from './binaural-dsp.js';
 
@@ -815,6 +815,24 @@ class AudioContextManager {
      */
     isReady() {
         return this.isInitialized && this.audioContext !== null;
+    }
+
+    /**
+     * Check if a media element is currently routed through this Web Audio graph.
+     * @param {HTMLMediaElement} audioElement
+     * @returns {boolean}
+     */
+    isElementRoutedToAudioContext(audioElement = this.audio) {
+        if (!this.isReady() || !audioElement) return false;
+        if (this.audio !== audioElement) return false;
+        if (!this.source || this.sources.get(audioElement) !== this.source) return false;
+
+        const sourceUrl = (audioElement.currentSrc || audioElement.src || '').toLowerCase();
+        const isNativeAppleHls =
+            (isIos || isSafari) &&
+            (sourceUrl.includes('.m3u8') || sourceUrl.includes('application/vnd.apple.mpegurl'));
+
+        return !isNativeAppleHls;
     }
 
     /**

--- a/js/audio-context.js
+++ b/js/audio-context.js
@@ -830,9 +830,10 @@ class AudioContextManager {
         if (!this.source || this.sources.get(audioElement) !== this.source) return false;
 
         const sourceUrl = (audioElement.currentSrc || audioElement.src || '').toLowerCase();
+        const sourceType = (audioElement.getAttribute('type') || audioElement.type || '').toLowerCase();
         const isNativeAppleHls =
             (isIos || isSafari) &&
-            (sourceUrl.includes('.m3u8') || sourceUrl.includes('application/vnd.apple.mpegurl'));
+            (sourceUrl.includes('.m3u8') || sourceType.includes('application/vnd.apple.mpegurl'));
 
         return !isNativeAppleHls;
     }

--- a/js/audio-context.js
+++ b/js/audio-context.js
@@ -475,8 +475,8 @@ class AudioContextManager {
 
         this.audio = audioElement;
 
-        if (isIos) {
-            console.log('[AudioContext] Skipping Web Audio initialization on iOS for lock screen compatibility');
+        if (isIos && !window.MediaSource && !window.ManagedMediaSource) {
+            console.log('[AudioContext] Skipping Web Audio on iOS without MSE support');
             return;
         }
 
@@ -772,7 +772,7 @@ class AudioContextManager {
 
         console.log('[AudioContext] Current state:', this.audioContext.state);
 
-        if (this.audioContext.state === 'suspended') {
+        if (this.audioContext.state === 'suspended' || this.audioContext.state === 'interrupted') {
             try {
                 await this.audioContext.resume();
                 console.log('[AudioContext] Resumed successfully, state:', this.audioContext.state);

--- a/js/audio-context.js
+++ b/js/audio-context.js
@@ -476,7 +476,7 @@ class AudioContextManager {
         this.audio = audioElement;
 
         if (isIos && !window.MediaSource && !window.ManagedMediaSource) {
-            console.log('[AudioContext] Skipping Web Audio on iOS without MSE support');
+            console.log('[AudioContext] Skipping Web Audio on iOS without MSE for lock screen compatibility');
             return;
         }
 
@@ -819,6 +819,8 @@ class AudioContextManager {
 
     /**
      * Check if a media element is currently routed through this Web Audio graph.
+     * Native Apple HLS playback can bypass createMediaElementSource(), so this
+     * returns false for that path to preserve direct element-volume handling.
      * @param {HTMLMediaElement} audioElement
      * @returns {boolean}
      */

--- a/js/player.js
+++ b/js/player.js
@@ -257,18 +257,10 @@ export class Player {
         const el = this.activeElement;
 
         // Apply to audio element and/or Web Audio graph
-        const isApple = isIos || isSafari;
-
-        if (audioContextManager.isReady() && !isApple) {
-            // If Web Audio is active, we apply volume there for better compatibility
-            // Especially on Linux where audio.volume might not affect the Web Audio graph
+        if (audioContextManager.isReady()) {
             el.volume = 1.0;
             audioContextManager.setVolume(effectiveVolume);
         } else {
-            // Safari bypasses WebAudio for HLS, so we MUST set el.volume directly to reflect ReplayGain
-            if (audioContextManager.isReady()) {
-                audioContextManager.setVolume(1.0); // Reset graph gain if it somehow routes
-            }
             el.volume = Math.max(0, Math.min(1, effectiveVolume));
         }
     }

--- a/js/player.js
+++ b/js/player.js
@@ -257,7 +257,7 @@ export class Player {
         const el = this.activeElement;
 
         // Apply to audio element and/or Web Audio graph
-        if (audioContextManager.isReady()) {
+        if (audioContextManager.isElementRoutedToAudioContext(el)) {
             el.volume = 1.0;
             audioContextManager.setVolume(effectiveVolume);
         } else {

--- a/js/settings.js
+++ b/js/settings.js
@@ -1241,6 +1241,22 @@ export async function initializeSettings(scrobbler, player, api, ui) {
         });
     }
 
+    // Binaural How-To Panel
+    const binauralHowtoBtn = document.getElementById('binaural-howto-btn');
+    const binauralHowtoPanel = document.getElementById('binaural-howto-panel');
+    const binauralHowtoClose = document.getElementById('binaural-howto-close');
+    if (binauralHowtoBtn && binauralHowtoPanel) {
+        binauralHowtoBtn.addEventListener('click', () => {
+            const visible = binauralHowtoPanel.style.display !== 'none';
+            binauralHowtoPanel.style.display = visible ? 'none' : '';
+        });
+        if (binauralHowtoClose) {
+            binauralHowtoClose.addEventListener('click', () => {
+                binauralHowtoPanel.style.display = 'none';
+            });
+        }
+    }
+
     // Listen for binaural mode changes (multichannel detection)
     window.addEventListener('binaural-mode-changed', (e) => {
         const statusEl = document.getElementById('binaural-status');

--- a/js/tests/api-manifest-type.test.js
+++ b/js/tests/api-manifest-type.test.js
@@ -1,0 +1,86 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const TRACK_MANIFEST_RESPONSE = {
+    data: {
+        data: {
+            attributes: {
+                uri: 'https://example.test/stream.mpd',
+                trackAudioNormalizationData: {},
+                albumAudioNormalizationData: {},
+            },
+        },
+    },
+};
+
+function setWindowProp(name, value) {
+    Object.defineProperty(window, name, {
+        configurable: true,
+        writable: true,
+        value,
+    });
+}
+
+async function requestManifestType({ mediaSource, managedMediaSource }) {
+    vi.resetModules();
+    vi.doMock('../platform-detection.js', () => ({
+        isIos: true,
+        isSafari: true,
+    }));
+
+    const { LosslessAPI } = await import('../api.js');
+    const api = new LosslessAPI({
+        getInstances: vi.fn(async () => [{ url: 'https://example.test', version: '3.0' }]),
+    });
+
+    setWindowProp('MediaSource', mediaSource);
+    setWindowProp('ManagedMediaSource', managedMediaSource);
+
+    const fetchWithRetry = vi.spyOn(api, 'fetchWithRetry').mockResolvedValue({
+        json: async () => TRACK_MANIFEST_RESPONSE,
+    });
+
+    await api.getStreamUrl('123');
+
+    const requestPath = fetchWithRetry.mock.calls[0][0];
+    const params = new URLSearchParams(requestPath.split('?')[1]);
+    return params.get('manifestType');
+}
+
+describe('LosslessAPI manifestType selection on Apple platforms', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    test('uses MPEG_DASH when MediaSource is available', async () => {
+        const manifestType = await requestManifestType({
+            mediaSource: class MediaSourceStub {},
+            managedMediaSource: undefined,
+        });
+
+        expect(manifestType).toBe('MPEG_DASH');
+    });
+
+    test('uses MPEG_DASH when ManagedMediaSource is available', async () => {
+        const manifestType = await requestManifestType({
+            mediaSource: undefined,
+            managedMediaSource: class ManagedMediaSourceStub {},
+        });
+
+        expect(manifestType).toBe('MPEG_DASH');
+    });
+
+    test('uses HLS when neither MediaSource nor ManagedMediaSource is available', async () => {
+        const manifestType = await requestManifestType({
+            mediaSource: undefined,
+            managedMediaSource: undefined,
+        });
+
+        expect(manifestType).toBe('HLS');
+    });
+});

--- a/js/tests/player-replaygain-routing.test.js
+++ b/js/tests/player-replaygain-routing.test.js
@@ -1,13 +1,12 @@
-import { expect, test, describe, beforeEach, vi, afterEach } from 'vitest';
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 import { Player } from '../player.js';
-import { REPEAT_MODE } from '../utils.js';
-import { audioEffectsSettings } from '../storage.js';
+import { audioContextManager } from '../audio-context.js';
 
 vi.mock('../audio-context.js', () => ({
     audioContextManager: {
         init: vi.fn(),
         resume: vi.fn(() => Promise.resolve()),
-        isReady: vi.fn(() => false),
+        isReady: vi.fn(() => true),
         isElementRoutedToAudioContext: vi.fn(() => false),
         setVolume: vi.fn(),
         changeSource: vi.fn(),
@@ -45,10 +44,7 @@ vi.mock('../storage.js', () => ({
     lastFMStorage: { isEnabled: vi.fn(() => false) },
     nowPlayingSettings: { getMode: vi.fn(() => 'cover') },
     gaplessPlaybackSettings: { isEnabled: vi.fn(() => true) },
-    binauralDspSettings: {
-        isEnabled: vi.fn(() => false),
-        getAutoEnableForSpatial: vi.fn(() => false),
-    },
+    binauralDspSettings: { isEnabled: vi.fn(() => false) },
 }));
 
 vi.mock('../db.js', () => ({
@@ -96,12 +92,11 @@ vi.mock('shaka-player', () => ({
     },
 }));
 
-describe('Player', () => {
+describe('Player replay gain volume routing', () => {
     let audioElement;
-    let api;
     let player;
 
-    beforeEach(async () => {
+    beforeEach(() => {
         document.body.innerHTML = `
             <audio id="audio-player"></audio>
             <video id="video-player"></video>
@@ -115,86 +110,38 @@ describe('Player', () => {
         `;
 
         audioElement = document.getElementById('audio-player');
-        api = {
-            getCoverUrl: vi.fn((id) => `url-${id}`),
+        Player._instance = null;
+        player = new Player(audioElement, {
+            getCoverUrl: vi.fn(),
             getCoverSrcset: vi.fn(),
             getStreamUrl: vi.fn(),
-        };
+        });
 
-        Player._instance = null;
+        audioContextManager.setVolume.mockClear();
+        audioContextManager.isElementRoutedToAudioContext.mockClear();
     });
 
     afterEach(() => {
         vi.clearAllMocks();
     });
 
-    test('initialization sets up initial state', async () => {
-        player = new Player(audioElement, api);
-        expect(player.audio).toBe(audioElement);
-        expect(player.api).toBe(api);
-        expect(player.queue).toEqual([]);
-        expect(player.shuffleActive).toBe(false);
+    test('routes through Web Audio gain when the active element is routed to audio context', () => {
+        player.userVolume = 0.55;
+        audioContextManager.isElementRoutedToAudioContext.mockReturnValue(true);
+
+        player.applyReplayGain();
+
+        expect(audioElement.volume).toBe(1);
+        expect(audioContextManager.setVolume).toHaveBeenCalledWith(0.55);
     });
 
-    test('setVolume updates userVolume and localStorage', () => {
-        player = new Player(audioElement, api);
-        player.setVolume(0.5);
-        expect(player.userVolume).toBe(0.5);
-        expect(localStorage.getItem('volume')).toBe('0.5');
-    });
+    test('keeps native media element volume when active element is not routed to audio context', () => {
+        player.userVolume = 0.35;
+        audioContextManager.isElementRoutedToAudioContext.mockReturnValue(false);
 
-    test('shuffle toggles correctly', () => {
-        player = new Player(audioElement, api);
-        player.queue = [{ id: 1 }, { id: 2 }, { id: 3 }];
+        player.applyReplayGain();
 
-        player.toggleShuffle();
-        expect(player.shuffleActive).toBe(true);
-        expect(player.shuffledQueue.length).toBe(3);
-
-        player.toggleShuffle();
-        expect(player.shuffleActive).toBe(false);
-    });
-
-    test('repeat mode cycles correctly', () => {
-        player = new Player(audioElement, api);
-        expect(player.repeatMode).toBe(REPEAT_MODE.OFF);
-
-        player.toggleRepeat();
-        expect(player.repeatMode).toBe(REPEAT_MODE.ALL);
-
-        player.toggleRepeat();
-        expect(player.repeatMode).toBe(REPEAT_MODE.ONE);
-
-        player.toggleRepeat();
-        expect(player.repeatMode).toBe(REPEAT_MODE.OFF);
-    });
-
-    test('addToQueue adds tracks to the end', async () => {
-        player = new Player(audioElement, api);
-        player.queue = [{ id: 1 }];
-
-        await player.addToQueue([{ id: 2 }, { id: 3 }]);
-        expect(player.queue.length).toBe(3);
-        expect(player.queue[2].id).toBe(3);
-    });
-
-    test('clearQueue resets queue state', async () => {
-        player = new Player(audioElement, api);
-        player.queue = [{ id: 1 }];
-        player.currentQueueIndex = 0;
-
-        await player.clearQueue();
-        expect(player.queue).toEqual([]);
-        expect(player.currentQueueIndex).toBe(-1);
-    });
-
-    test('setPlaybackSpeed clamps values', () => {
-        player = new Player(audioElement, api);
-
-        player.setPlaybackSpeed(2.0);
-        expect(audioEffectsSettings.setSpeed).toHaveBeenCalledWith(2.0);
-
-        player.setPlaybackSpeed(0);
-        expect(audioEffectsSettings.setSpeed).toHaveBeenCalledWith(0.01);
+        expect(audioElement.volume).toBe(0.35);
+        expect(audioContextManager.setVolume).not.toHaveBeenCalled();
     });
 });

--- a/js/tests/player-replaygain-routing.test.js
+++ b/js/tests/player-replaygain-routing.test.js
@@ -110,7 +110,6 @@ describe('Player replay gain volume routing', () => {
         `;
 
         audioElement = document.getElementById('audio-player');
-        Player._instance = null;
         player = new Player(audioElement, {
             getCoverUrl: vi.fn(),
             getCoverSrcset: vi.fn(),

--- a/js/tests/player-replaygain-routing.test.js
+++ b/js/tests/player-replaygain-routing.test.js
@@ -132,7 +132,7 @@ describe('Player replay gain volume routing', () => {
         player.applyReplayGain();
 
         expect(audioElement.volume).toBe(1);
-        expect(audioContextManager.setVolume).toHaveBeenCalledWith(0.55);
+        expect(audioContextManager.setVolume.mock.calls).toEqual([[0.55]]);
     });
 
     test('keeps native media element volume when active element is not routed to audio context', () => {
@@ -142,6 +142,6 @@ describe('Player replay gain volume routing', () => {
         player.applyReplayGain();
 
         expect(audioElement.volume).toBe(0.35);
-        expect(audioContextManager.setVolume).not.toHaveBeenCalled();
+        expect(audioContextManager.setVolume.mock.calls).toHaveLength(0);
     });
 });

--- a/js/tests/player.test.js
+++ b/js/tests/player.test.js
@@ -192,9 +192,9 @@ describe('Player', () => {
         player = new Player(audioElement, api);
 
         player.setPlaybackSpeed(2.0);
-        expect(audioEffectsSettings.setSpeed.mock.calls[0]).toEqual([2.0]);
+        expect(audioEffectsSettings.setSpeed.mock.calls).toEqual([[2.0]]);
 
         player.setPlaybackSpeed(0);
-        expect(audioEffectsSettings.setSpeed.mock.calls[1]).toEqual([0.01]);
+        expect(audioEffectsSettings.setSpeed.mock.calls).toEqual([[2.0], [0.01]]);
     });
 });

--- a/js/tests/player.test.js
+++ b/js/tests/player.test.js
@@ -192,9 +192,9 @@ describe('Player', () => {
         player = new Player(audioElement, api);
 
         player.setPlaybackSpeed(2.0);
-        expect(audioEffectsSettings.setSpeed).toHaveBeenCalledWith(2.0);
+        expect(audioEffectsSettings.setSpeed.mock.calls[0]).toEqual([2.0]);
 
         player.setPlaybackSpeed(0);
-        expect(audioEffectsSettings.setSpeed).toHaveBeenCalledWith(0.01);
+        expect(audioEffectsSettings.setSpeed.mock.calls[1]).toEqual([0.01]);
     });
 });

--- a/js/tests/player.test.js
+++ b/js/tests/player.test.js
@@ -44,6 +44,10 @@ vi.mock('../storage.js', () => ({
     lastFMStorage: { isEnabled: vi.fn(() => false) },
     nowPlayingSettings: { getMode: vi.fn(() => 'cover') },
     gaplessPlaybackSettings: { isEnabled: vi.fn(() => true) },
+    binauralDspSettings: {
+        isEnabled: vi.fn(() => false),
+        getAutoEnableForSpatial: vi.fn(() => false),
+    },
 }));
 
 vi.mock('../db.js', () => ({

--- a/styles.css
+++ b/styles.css
@@ -11212,6 +11212,13 @@ body:has(#side-panel.active) #close-fullscreen-cover-btn {
     border-bottom: 1px solid var(--border);
 }
 
+.binaural-header-row {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    margin-bottom: var(--spacing-md);
+}
+
 .binaural-status {
     padding: var(--spacing-sm) var(--spacing-md);
     margin-bottom: var(--spacing-md);
@@ -11219,6 +11226,12 @@ body:has(#side-panel.active) #close-fullscreen-cover-btn {
     border-radius: var(--radius-md);
     font-size: 0.85rem;
     color: var(--muted-foreground);
+}
+
+/* stylelint-disable-next-line no-descending-specificity */
+.binaural-header-row .binaural-status {
+    flex: 1;
+    margin-bottom: 0;
 }
 
 .binaural-mode-label {

--- a/styles.css
+++ b/styles.css
@@ -11212,26 +11212,16 @@ body:has(#side-panel.active) #close-fullscreen-cover-btn {
     border-bottom: 1px solid var(--border);
 }
 
-.binaural-header-row {
+.binaural-status {
     display: flex;
     align-items: center;
-    gap: var(--spacing-sm);
-    margin-bottom: var(--spacing-md);
-}
-
-.binaural-status {
+    justify-content: space-between;
     padding: var(--spacing-sm) var(--spacing-md);
     margin-bottom: var(--spacing-md);
     background: var(--secondary);
     border-radius: var(--radius-md);
     font-size: 0.85rem;
     color: var(--muted-foreground);
-}
-
-/* stylelint-disable-next-line no-descending-specificity */
-.binaural-header-row .binaural-status {
-    flex: 1;
-    margin-bottom: 0;
 }
 
 .binaural-mode-label {


### PR DESCRIPTION


Enable Web Audio Effects on iOS Safari

This PR adds support for audio effects (EQ, DSP) on modern iOS Safari by switching from native HLS to DASH streaming with MediaSource Extensions (MSE). When ManagedMediaSource is available (iOS 17+), the app now uses Shaka Player for DASH playback, routing audio through the Web Audio API where effects are properly applied. Includes iOS audio session interrupt handling, proper gain staging, and expanded test coverage for Safari routing behavior.

Safari's native HLS decoder bypasses the Web Audio API entirely, preventing effects from being processed. The solution implemented switches to DASH + MSE, which ensures audio flows through your effects graph where EQ and DSP can operate a platform specific routing pattern common in web audio apps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Binaural/Spatial DSP “How to use” tutorial panel with a toggle button and close control.

* **Bug Fixes**
  * Stream format selection now detects runtime media capabilities and prefers MPEG‑DASH when supported, falling back to HLS only when necessary.
  * Web Audio initialization, resume, and volume handling now respect runtime capability and routing so native HLS playback is not routed through the Web Audio chain.

* **Tests**
  * Added tests for manifest type selection and audio volume routing behavior.

* **Style**
  * Updated layout styles for the binaural header/status area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->