### PR TITLE
fix(ui): fix audio slider not updating

### DIFF
--- a/js/audio-context.js
+++ b/js/audio-context.js
@@ -826,6 +826,7 @@ class AudioContextManager {
         if (this.volumeNode && this.audioContext) {
             const now = this.audioContext.currentTime;
             this.volumeNode.gain.setTargetAtTime(this.currentVolume, now, 0.01);
+            window.dispatchEvent(new CustomEvent('volume-change'));
         }
     }
 

--- a/js/events.js
+++ b/js/events.js
@@ -518,6 +518,8 @@ export function initializePlayerEvents(player, audioPlayer, scrobbler, ui) {
         });
     };
 
+    window.addEventListener('volume-change', updateVolumeUI);
+
     setupMediaListeners(audioPlayer);
     if (player.video) {
         setupMediaListeners(player.video);

--- a/js/ui.js
+++ b/js/ui.js
@@ -2280,6 +2280,7 @@ export class UIRenderer {
             });
 
             this.player.activeElement.addEventListener('volumechange', updateFsVolumeUI);
+            window.addEventListener('volume-change', updateFsVolumeUI);
             updateFsVolumeUI();
         }
 


### PR DESCRIPTION
### Description

Pressing up/down arrows while playing tracks changed volume without modifying the volume slider position.
This was caused by the slider being modified on the MediaElement.onvoumechange event; this event was not fired when changing volume via audioContext.gain.

Proposed fix: fire a window event on audio-context.setVolume and use it as well for redrawing the slider

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist

- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.
- [ ] Is this Pull request Using AI/Is Vibecoded?

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volume UI consistency across different playback modes, ensuring volume control feedback is reliably displayed in both standard and fullscreen playback contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->