### PR TITLE
fix(metadata): (m4a) write artist metadata into the right tags

### DIFF
--- a/js/metadata.js
+++ b/js/metadata.js
@@ -51,7 +51,7 @@ export async function addMetadataToAudio(audioBlob, track, _api, _quality, prefe
         data.title = getTrackTitle(track);
         data.artist = getFullArtistArray(track);
         data.albumTitle = track.album?.title;
-        data.albumArtist = track.album?.artist?.name || getFullArtistString(track) || '';
+        data.albumArtist = track.album?.artist?.name || track.artist?.name;
         data.trackNumber = track.trackNumber;
         data.discNumber = track.volumeNumber ?? track.discNumber;
         data.totalTracks = track.album?.numberOfTracksOnDisc ?? track.album?.numberOfTracks;


### PR DESCRIPTION
### Description
Artist metadata writes the track artists into albumArtist, and the real album artist into artist, when it should do the opposite.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist

- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.
- [ ] Is this Pull request Using AI/Is Vibecoded?

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved album artist metadata retrieval with enhanced fallback logic for more reliable information sourcing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->