### PR TITLE
fix(proxy-audio): Fix playing audio via the proxy audio

### DIFF
--- a/functions/proxy-audio.js
+++ b/functions/proxy-audio.js
@@ -24,6 +24,7 @@ export async function onRequest(context) {
             const headers = new Headers(request.headers);
             headers.delete('host');
             headers.delete('referer');
+            headers.delete('origin');
             headers.set(
                 'User-Agent',
                 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'

--- a/functions/proxy-audio.js
+++ b/functions/proxy-audio.js
@@ -7,12 +7,24 @@ export async function onRequest(context) {
         return new Response('Missing url parameter', { status: 400 });
     }
 
+    let tidalUrl;
+    try {
+        tidalUrl = new URL(targetUrl);
+    } catch {
+        return new Response('Invalid target URL', { status: 400 });
+    }
+
+    const host = tidalUrl.hostname;
+    if (
+        (tidalUrl.protocol !== 'https:' && tidalUrl.protocol !== 'http:') ||
+        !(host === 'tidal.com' || host.endsWith('.tidal.com'))
+    ) {
+        return new Response('Target host not allowed', { status: 400 });
+    }
+
     try {
         const cacheUrl = new URL(request.url);
-        try {
-            const tidalUrl = new URL(targetUrl);
-            cacheUrl.searchParams.set('cache_key', tidalUrl.pathname);
-        } catch (e) {}
+        cacheUrl.searchParams.set('cache_key', tidalUrl.pathname);
 
         const cacheKey = new Request(cacheUrl.toString(), request);
         const cache = caches.default;

--- a/js/player.js
+++ b/js/player.js
@@ -149,8 +149,13 @@ export class Player {
 
             this.shakaPlayer.getNetworkingEngine().registerRequestFilter((_type, request) => {
                 request.uris = request.uris.map((uri) => {
-                    if (uri && uri.includes('tidal.com') && !uri.startsWith('/proxy-audio')) {
-                        return `/proxy-audio?url=${encodeURIComponent(uri)}`;
+                    try {
+                        const { hostname } = new URL(uri);
+                        if (hostname === 'tidal.com' || hostname.endsWith('.tidal.com')) {
+                            return `/proxy-audio?url=${encodeURIComponent(uri)}`;
+                        }
+                    } catch {
+                        // unparseable URI — leave unchanged
                     }
                     return uri;
                 });

--- a/js/player.js
+++ b/js/player.js
@@ -147,6 +147,15 @@ export class Player {
             this.shakaPlayer.addEventListener('adaptation', this.updateAdaptiveQualityBadge.bind(this));
             this.shakaPlayer.addEventListener('variantchanged', this.updateAdaptiveQualityBadge.bind(this));
 
+            this.shakaPlayer.getNetworkingEngine().registerRequestFilter((_type, request) => {
+                request.uris = request.uris.map((uri) => {
+                    if (uri && uri.includes('tidal.com') && !uri.startsWith('/proxy-audio')) {
+                        return `/proxy-audio?url=${encodeURIComponent(uri)}`;
+                    }
+                    return uri;
+                });
+            });
+
             this.shakaInitialized = false;
 
             // Monitor and bridge different codec groups (e.g. AAC to FLAC) since native ABR isolates them

--- a/js/tests/player.test.js
+++ b/js/tests/player.test.js
@@ -59,6 +59,8 @@ vi.mock('../ui.js', () => ({
     },
 }));
 
+let shakaRequestFilter = null;
+
 vi.mock('shaka-player', () => ({
     default: {
         polyfill: { installAll: vi.fn() },
@@ -79,6 +81,13 @@ vi.mock('shaka-player', () => ({
         }
         configure() {}
         addEventListener() {}
+        getNetworkingEngine() {
+            return {
+                registerRequestFilter(fn) {
+                    shakaRequestFilter = fn;
+                },
+            };
+        }
         load() {
             return Promise.resolve();
         }
@@ -191,5 +200,40 @@ describe('Player', () => {
 
         player.setPlaybackSpeed(0);
         expect(audioEffectsSettings.setSpeed).toHaveBeenCalledWith(0.01);
+    });
+
+    test('Shaka request filter rewrites tidal.com URIs through proxy and leaves others unchanged', async () => {
+        shakaRequestFilter = null;
+        player = new Player(audioElement, api);
+        await player.init();
+
+        expect(shakaRequestFilter).toBeTypeOf('function');
+
+        const applyFilter = (uris) => {
+            const req = { uris: [...uris] };
+            shakaRequestFilter(null, req);
+            return req.uris;
+        };
+
+        // TIDAL subdomain → proxied
+        expect(applyFilter(['https://lgf.audio.tidal.com/mediatracks/abc.flac?token=xyz'])).toEqual([
+            '/proxy-audio?url=https%3A%2F%2Flgf.audio.tidal.com%2Fmediatracks%2Fabc.flac%3Ftoken%3Dxyz',
+        ]);
+
+        // tidal.com apex → proxied
+        expect(applyFilter(['https://tidal.com/some/path'])).toEqual([
+            '/proxy-audio?url=https%3A%2F%2Ftidal.com%2Fsome%2Fpath',
+        ]);
+
+        // Lookalike hostname → NOT proxied
+        expect(applyFilter(['https://evil-tidal.com/audio.flac'])).toEqual([
+            'https://evil-tidal.com/audio.flac',
+        ]);
+
+        // Non-TIDAL CDN → NOT proxied
+        expect(applyFilter(['https://example.com/audio.mp4'])).toEqual(['https://example.com/audio.mp4']);
+
+        // Blob URLs (DASH manifests) → NOT proxied
+        expect(applyFilter(['blob:http://localhost/some-uuid'])).toEqual(['blob:http://localhost/some-uuid']);
     });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'node:stream';
 import { defineConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
 import authGatePlugin from './vite-plugin-auth-gate.js';
@@ -83,42 +84,79 @@ export default defineConfig((_options) => {
             {
                 name: 'proxy-audio-dev',
                 configureServer(server) {
-                    server.middlewares.use('/proxy-audio', async (req, res) => {
-                        const urlParam = new URL(req.url!, `http://${req.headers.host}`).searchParams.get('url');
+                    server.middlewares.use('/proxy-audio', (req, res, _next) => {
+                        let urlParam: string | null;
+                        try {
+                            urlParam = new URL(req.url ?? '', `http://${req.headers.host ?? 'localhost'}`).searchParams.get('url');
+                        } catch {
+                            res.writeHead(400);
+                            res.end('Invalid request URL');
+                            return;
+                        }
+
                         if (!urlParam) {
                             res.writeHead(400);
                             res.end('Missing url parameter');
                             return;
                         }
+
+                        let parsed: URL;
                         try {
-                            const upstream = await fetch(urlParam, {
+                            parsed = new URL(urlParam);
+                        } catch {
+                            res.writeHead(400);
+                            res.end('Invalid target URL');
+                            return;
+                        }
+
+                        const host = parsed.hostname;
+                        if (
+                            (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') ||
+                            !(host === 'tidal.com' || host.endsWith('.tidal.com'))
+                        ) {
+                            res.writeHead(400);
+                            res.end('Target host not allowed');
+                            return;
+                        }
+
+                        (async () => {
+                            const upstream = await fetch(urlParam!, {
                                 method: req.method ?? 'GET',
                                 headers: {
                                     'User-Agent':
                                         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-                                    ...(req.headers.range ? { range: req.headers.range } : {}),
+                                    ...(req.headers.range ? { range: req.headers.range as string } : {}),
                                 },
                                 redirect: 'follow',
                             });
-                            res.writeHead(upstream.status, {
+
+                            const headers: Record<string, string> = {
                                 'content-type': upstream.headers.get('content-type') ?? 'application/octet-stream',
-                                'content-length': upstream.headers.get('content-length') ?? '',
-                                'accept-ranges': upstream.headers.get('accept-ranges') ?? 'bytes',
-                                'content-range': upstream.headers.get('content-range') ?? '',
                                 'access-control-allow-origin': '*',
-                            });
-                            const reader = upstream.body!.getReader();
-                            const pump = async () => {
-                                const { done, value } = await reader.read();
-                                if (done) { res.end(); return; }
-                                res.write(value);
-                                await pump();
                             };
-                            await pump();
-                        } catch (e: any) {
-                            res.writeHead(500);
+                            const contentLength = upstream.headers.get('content-length');
+                            const contentRange = upstream.headers.get('content-range');
+                            const acceptRanges = upstream.headers.get('accept-ranges');
+                            if (contentLength) headers['content-length'] = contentLength;
+                            if (contentRange) headers['content-range'] = contentRange;
+                            if (acceptRanges) headers['accept-ranges'] = acceptRanges;
+
+                            res.writeHead(upstream.status, headers);
+
+                            if (!upstream.body) {
+                                res.end();
+                                return;
+                            }
+
+                            const nodeStream = Readable.fromWeb(upstream.body as any);
+                            req.on('close', () => nodeStream.destroy());
+                            nodeStream.pipe(res);
+                        })().catch((e: any) => {
+                            if (!res.headersSent) {
+                                res.writeHead(500);
+                            }
                             res.end('Proxy error: ' + e.message);
-                        }
+                        });
                     });
                 },
             },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -80,6 +80,48 @@ export default defineConfig((_options) => {
             },
         },
         plugins: [
+            {
+                name: 'proxy-audio-dev',
+                configureServer(server) {
+                    server.middlewares.use('/proxy-audio', async (req, res) => {
+                        const urlParam = new URL(req.url!, `http://${req.headers.host}`).searchParams.get('url');
+                        if (!urlParam) {
+                            res.writeHead(400);
+                            res.end('Missing url parameter');
+                            return;
+                        }
+                        try {
+                            const upstream = await fetch(urlParam, {
+                                method: req.method ?? 'GET',
+                                headers: {
+                                    'User-Agent':
+                                        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+                                    ...(req.headers.range ? { range: req.headers.range } : {}),
+                                },
+                                redirect: 'follow',
+                            });
+                            res.writeHead(upstream.status, {
+                                'content-type': upstream.headers.get('content-type') ?? 'application/octet-stream',
+                                'content-length': upstream.headers.get('content-length') ?? '',
+                                'accept-ranges': upstream.headers.get('accept-ranges') ?? 'bytes',
+                                'content-range': upstream.headers.get('content-range') ?? '',
+                                'access-control-allow-origin': '*',
+                            });
+                            const reader = upstream.body!.getReader();
+                            const pump = async () => {
+                                const { done, value } = await reader.read();
+                                if (done) { res.end(); return; }
+                                res.write(value);
+                                await pump();
+                            };
+                            await pump();
+                        } catch (e: any) {
+                            res.writeHead(500);
+                            res.end('Proxy error: ' + e.message);
+                        }
+                    });
+                },
+            },
             purgecss({
                 variables: false, // DO NOT REMOVE UNUSED VARIABLES (breaks web components like am-lyrics)
                 safelist: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import { defineConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
 import authGatePlugin from './vite-plugin-auth-gate.js';
@@ -150,12 +151,15 @@ export default defineConfig((_options) => {
 
                             const nodeStream = Readable.fromWeb(upstream.body as any);
                             req.on('close', () => nodeStream.destroy());
-                            nodeStream.pipe(res);
+                            await pipeline(nodeStream, res);
                         })().catch((e: any) => {
+                            if (res.writableEnded || res.destroyed) return;
                             if (!res.headersSent) {
                                 res.writeHead(500);
+                                res.end('Proxy error: ' + (e instanceof Error ? e.message : String(e)));
+                                return;
                             }
-                            res.end('Proxy error: ' + e.message);
+                            res.destroy(e);
                         });
                     });
                 },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -121,6 +121,10 @@ export default defineConfig((_options) => {
                         }
 
                         (async () => {
+                            const controller = new AbortController();
+                            const onClose = () => controller.abort();
+                            req.on('close', onClose);
+
                             const upstream = await fetch(urlParam!, {
                                 method: req.method ?? 'GET',
                                 headers: {
@@ -129,6 +133,7 @@ export default defineConfig((_options) => {
                                     ...(req.headers.range ? { range: req.headers.range as string } : {}),
                                 },
                                 redirect: 'follow',
+                                signal: controller.signal,
                             });
 
                             const headers: Record<string, string> = {
@@ -145,13 +150,17 @@ export default defineConfig((_options) => {
                             res.writeHead(upstream.status, headers);
 
                             if (!upstream.body) {
+                                req.off('close', onClose);
                                 res.end();
                                 return;
                             }
 
                             const nodeStream = Readable.fromWeb(upstream.body as any);
-                            req.on('close', () => nodeStream.destroy());
-                            await pipeline(nodeStream, res);
+                            try {
+                                await pipeline(nodeStream, res);
+                            } finally {
+                                req.off('close', onClose);
+                            }
                         })().catch((e: any) => {
                             if (res.writableEnded || res.destroyed) return;
                             if (!res.headersSent) {


### PR DESCRIPTION
### Description

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist

- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.
- [x] Is this Pull request Using AI/Is Vibecoded? AI Assisted - i'm a SE by profession and everything has been verified and is following my own code standards

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an audio proxy endpoint and client-side rewrite so Tidal stream requests are routed through the proxy.
  * Dev server exposes the same proxy behavior for local testing, including range support and streamed responses.

* **Bug Fixes / Improvements**
  * Stronger validation of proxied URLs with stricter host/protocol restrictions.
  * Reduced forwarded headers for better privacy/compatibility.

* **Tests**
  * Added unit tests validating URI-rewrite behavior and allowed/disallowed hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->