### PR TITLE
fix: use NetworkOnly for audio/video in workbox config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -133,7 +133,7 @@ export default defineConfig((_options) => {
                         {
                             urlPattern: ({ request }) =>
                                 request.destination === 'audio' || request.destination === 'video',
-                            handler: 'CacheFirst',
+                            handler: 'NetworkOnly',
                             options: {
                                 cacheName: 'media',
                                 expiration: {


### PR DESCRIPTION
## Problem

The workbox runtime caching config uses `CacheFirst` for audio/video requests. When streaming from CDNs that don't serve CORS headers (e.g. Tidal's `amz-pr-fa.audio.tidal.com`), the service worker intercepts the fetch and tries to cache the response. Without `Access-Control-Allow-Origin`, the opaque response can't be read by workbox, resulting in a `no-response` error and silent playback failure.

Console output:

```
Access to fetch at 'https://amz-pr-fa.audio.tidal.com/...' has been blocked by CORS policy:
No 'Access-Control-Allow-Origin' header is present on the requested resource.

Uncaught (in promise) no-response: no-response :: [{"url":"https://amz-pr-fa.audio.tidal.com/...","error":{}}]
```

## Fix

Change the workbox handler for `audio || video` requests from `CacheFirst` to `NetworkOnly`. This bypasses the service worker cache entirely for media streams and lets the browser handle them directly.

Images remain `CacheFirst` since cover art CDNs serve proper CORS headers.

## Changes

One line in `vite.config.ts`:

```diff
-  handler: 'CacheFirst',
+  handler: 'NetworkOnly',
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified the caching behavior for audio and video media files. The application now prioritizes fetching the latest media content directly from the network instead of serving cached versions initially. This approach ensures users receive the most current and up-to-date media while still maintaining offline availability through fallback cache mechanisms for uninterrupted service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->