### PR TITLE
add super cool cd thing trust

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,12 +261,25 @@
                 <div class="fullscreen-shell">
                     <div class="fullscreen-main-view">
                         <div class="fullscreen-media-column">
-                            <div class="fullscreen-artwork-card">
+                            <div class="fullscreen-artwork-card" id="fullscreen-artwork-card">
                                 <img
                                     id="fullscreen-cover-image"
                                     src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
                                     alt="Album Cover"
                                 />
+                                <div class="cd-ring" id="cd-ring"></div>
+                                <svg width="0" height="0">
+                                    <defs>
+                                        <clipPath id="cd-hole-clip" clipPathUnits="objectBoundingBox">
+                                            <path fill-rule="evenodd"
+                                                d="M0,0 H1 V1 H0 Z
+                                                M0.5,0.5
+                                                m-0.069,0
+                                                a0.069,0.069 0 1,0 0.138,0
+                                                a0.069,0.069 0 1,0 -0.138,0 Z"/>
+                                        </clipPath>
+                                    </defs>
+                                </svg>
                             </div>
 
                             <div class="fullscreen-track-info">
@@ -3318,6 +3331,19 @@
                                     </div>
                                     <label class="toggle-switch">
                                         <input type="checkbox" id="butterchurn-randomize-toggle" />
+                                        <span class="slider"></span>
+                                    </label>
+                                </div>
+                                </div><div class="settings-group">
+                                <div class="setting-item" id="cd-album-cover-setting">
+                                    <div class="info">
+                                        <span class="label">CD Album Cover</span>
+                                        <span class="description"
+                                            >Spin album cover and add CD hole in fullscreen</span
+                                        >
+                                    </div>
+                                    <label class="toggle-switch">
+                                        <input type="checkbox" id="cd-album-cover-toggle" />
                                         <span class="slider"></span>
                                     </label>
                                 </div>

--- a/index.html
+++ b/index.html
@@ -3334,7 +3334,8 @@
                                         <span class="slider"></span>
                                     </label>
                                 </div>
-                                </div><div class="settings-group">
+                            </div>
+                            <div class="settings-group">
                                 <div class="setting-item" id="cd-album-cover-setting">
                                     <div class="info">
                                         <span class="label">CD Album Cover</span>

--- a/index.html
+++ b/index.html
@@ -3338,21 +3338,23 @@
                                 </div>
                             </div>
                             <div class="settings-group">
+                                <div class="setting-item" id="cd-album-cover-setting">
+                                    <div class="info">
                                         <span class="label" id="cd-album-cover-label">CD Album Cover</span>
                                         <span class="description" id="cd-album-cover-description"
                                             >Spin album cover and add CD hole in fullscreen</span
                                         >
                                     </div>
-                                    <label class="toggle-switch">
-                                        <input
-                                            type="checkbox"
-                                            id="cd-album-cover-toggle"
-                                            aria-labelledby="cd-album-cover-label"
-                                            aria-describedby="cd-album-cover-description"
-                                        />
-                                        <span class="slider"></span>
-                                    </label>
                                 </div>
+                                <label class="toggle-switch">
+                                    <input
+                                        type="checkbox"
+                                        id="cd-album-cover-toggle"
+                                        aria-labelledby="cd-album-cover-label"
+                                        aria-describedby="cd-album-cover-description"
+                                    />
+                                    <span class="slider"></span>
+                                </label>
                             </div>
                         </div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -3338,13 +3338,18 @@
                                 </div>
                             </div>
                             <div class="settings-group">
-                                <div class="setting-item" id="cd-album-cover-setting">
-                                    <div class="info">
-                                        <span class="label">CD Album Cover</span>
-                                        <span class="description">Spin album cover and add CD hole in fullscreen</span>
+                                        <span class="label" id="cd-album-cover-label">CD Album Cover</span>
+                                        <span class="description" id="cd-album-cover-description"
+                                            >Spin album cover and add CD hole in fullscreen</span
+                                        >
                                     </div>
                                     <label class="toggle-switch">
-                                        <input type="checkbox" id="cd-album-cover-toggle" />
+                                        <input
+                                            type="checkbox"
+                                            id="cd-album-cover-toggle"
+                                            aria-labelledby="cd-album-cover-label"
+                                            aria-describedby="cd-album-cover-description"
+                                        />
                                         <span class="slider"></span>
                                     </label>
                                 </div>

--- a/index.html
+++ b/index.html
@@ -271,12 +271,14 @@
                                 <svg width="0" height="0">
                                     <defs>
                                         <clipPath id="cd-hole-clip" clipPathUnits="objectBoundingBox">
-                                            <path fill-rule="evenodd"
+                                            <path
+                                                fill-rule="evenodd"
                                                 d="M0,0 H1 V1 H0 Z
                                                 M0.5,0.5
                                                 m-0.069,0
                                                 a0.069,0.069 0 1,0 0.138,0
-                                                a0.069,0.069 0 1,0 -0.138,0 Z"/>
+                                                a0.069,0.069 0 1,0 -0.138,0 Z"
+                                            />
                                         </clipPath>
                                     </defs>
                                 </svg>
@@ -3339,9 +3341,7 @@
                                 <div class="setting-item" id="cd-album-cover-setting">
                                     <div class="info">
                                         <span class="label">CD Album Cover</span>
-                                        <span class="description"
-                                            >Spin album cover and add CD hole in fullscreen</span
-                                        >
+                                        <span class="description">Spin album cover and add CD hole in fullscreen</span>
                                     </div>
                                     <label class="toggle-switch">
                                         <input type="checkbox" id="cd-album-cover-toggle" />

--- a/js/settings.js
+++ b/js/settings.js
@@ -6069,7 +6069,7 @@ export async function initializeSettings(scrobbler, player, api, ui) {
     }
 
     // Spins album cover and adds hole in fullscreen
-    const cdAlbumCoverToggle = document.getElementById("cd-album-cover-toggle");
+    const cdAlbumCoverToggle = document.getElementById('cd-album-cover-toggle');
 
     if (cdAlbumCoverToggle) {
         cdAlbumCoverToggle.checked = visualizerSettings.isCdAlbumCoverEnabled();

--- a/js/settings.js
+++ b/js/settings.js
@@ -6068,6 +6068,17 @@ export async function initializeSettings(scrobbler, player, api, ui) {
         observer.observe(appearanceTabContent, { attributes: true });
     }
 
+    // Spins album cover and adds hole in fullscreen
+    const cdAlbumCoverToggle = document.getElementById("cd-album-cover-toggle");
+
+    if (cdAlbumCoverToggle) {
+        cdAlbumCoverToggle.checked = visualizerSettings.isCdAlbumCoverEnabled();
+
+        cdAlbumCoverToggle.addEventListener('change', async (e) => {
+            visualizerSettings.setCdAlbumCoverEnabled(e.target.checked);
+        });
+    }
+
     // Watch for downloads tab becoming active and update setting visibility
     const downloadsTabContent = document.getElementById('settings-tab-downloads');
     if (downloadsTabContent) {

--- a/js/settings.js
+++ b/js/settings.js
@@ -6074,8 +6074,9 @@ export async function initializeSettings(scrobbler, player, api, ui) {
     if (cdAlbumCoverToggle) {
         cdAlbumCoverToggle.checked = visualizerSettings.isCdAlbumCoverEnabled();
 
-        cdAlbumCoverToggle.addEventListener('change', async (e) => {
+        cdAlbumCoverToggle.addEventListener('change', (e) => {
             visualizerSettings.setCdAlbumCoverEnabled(e.target.checked);
+            window.dispatchEvent(new CustomEvent('fullscreen-cover-settings-changed'));
         });
     }
 

--- a/js/storage.js
+++ b/js/storage.js
@@ -1082,17 +1082,19 @@ export const visualizerSettings = {
         localStorage.setItem('butterchurn-randomize-enabled', enabled);
     },
 
+    CD_ALBUM_COVER_KEY: 'cd-album-cover-enabled',
+
     // Spin album cover and add hole in fullscreen
     isCdAlbumCoverEnabled() {
         try {
-            return localStorage.getItem('cd-album-cover-enabled') === 'true';
+            return localStorage.getItem(this.CD_ALBUM_COVER_KEY) !== 'false';
         } catch {
             return true;
         }
     },
 
     setCdAlbumCoverEnabled(enabled) {
-        localStorage.setItem('cd-album-cover-enabled', enabled);
+        localStorage.setItem(this.CD_ALBUM_COVER_KEY, enabled ? 'true' : 'false');
     },
 };
 

--- a/js/storage.js
+++ b/js/storage.js
@@ -1081,6 +1081,19 @@ export const visualizerSettings = {
     setButterchurnRandomizeEnabled(enabled) {
         localStorage.setItem('butterchurn-randomize-enabled', enabled);
     },
+
+    // Spin album cover and add hole in fullscreen
+    isCdAlbumCoverEnabled() {
+        try {
+            return localStorage.getItem('cd-album-cover-enabled') === 'true';
+        } catch {
+            return true;
+        }
+    },
+
+    setCdAlbumCoverEnabled(enabled) {
+        localStorage.setItem('cd-album-cover-enabled', enabled);
+    },
 };
 
 export const equalizerSettings = {

--- a/js/storage.js
+++ b/js/storage.js
@@ -963,6 +963,7 @@ export const visualizerSettings = {
     PRESET_KEY: 'visualizer-preset',
     BUTTERCHURN_CYCLE_KEY: 'butterchurn-cycle-duration',
     DIM_AMOUNT_KEY: 'visualizer-dim-amount',
+    CD_ALBUM_COVER_KEY: 'cd-album-cover-enabled',
 
     getPreset() {
         try {
@@ -1081,8 +1082,6 @@ export const visualizerSettings = {
     setButterchurnRandomizeEnabled(enabled) {
         localStorage.setItem('butterchurn-randomize-enabled', enabled);
     },
-
-    CD_ALBUM_COVER_KEY: 'cd-album-cover-enabled',
 
     // Spin album cover and add hole in fullscreen
     isCdAlbumCoverEnabled() {

--- a/js/ui.js
+++ b/js/ui.js
@@ -1355,6 +1355,14 @@ export class UIRenderer {
         const lyricsPane = document.getElementById('fullscreen-lyrics-pane');
         const lyricsContent = document.getElementById('fullscreen-lyrics-content');
         const lyricsToggleBtn = document.getElementById('toggle-fullscreen-lyrics-btn');
+        const coverImage = document.getElementById('fullscreen-cover-image');
+        const coverCard = document.getElementById('fullscreen-artwork-card');
+        const cdRing = document.getElementById('cd-ring');
+        const isCdMode = visualizerSettings.isCdAlbumCoverEnabled();
+
+        coverImage.classList.toggle("cd", isCdMode);
+        coverCard.classList.toggle("cd", isCdMode);
+        cdRing.classList.toggle("cd", isCdMode);
 
         await this.updateFullscreenMetadata(track, nextTrack);
 
@@ -1414,7 +1422,6 @@ export class UIRenderer {
             overlay.classList.remove('fullscreen-cover-no-round');
         }
 
-        const coverImage = document.getElementById('fullscreen-cover-image');
         if (coverImage?.vanillaTilt) {
             coverImage.vanillaTilt.destroy();
         }

--- a/js/ui.js
+++ b/js/ui.js
@@ -1360,9 +1360,9 @@ export class UIRenderer {
         const cdRing = document.getElementById('cd-ring');
         const isCdMode = visualizerSettings.isCdAlbumCoverEnabled();
 
-        coverImage.classList.toggle("cd", isCdMode);
-        coverCard.classList.toggle("cd", isCdMode);
-        cdRing.classList.toggle("cd", isCdMode);
+        coverImage.classList.toggle('cd', isCdMode);
+        coverCard.classList.toggle('cd', isCdMode);
+        cdRing.classList.toggle('cd', isCdMode);
 
         await this.updateFullscreenMetadata(track, nextTrack);
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -1360,9 +1360,9 @@ export class UIRenderer {
         const cdRing = document.getElementById('cd-ring');
         const isCdMode = visualizerSettings.isCdAlbumCoverEnabled();
 
-        coverImage.classList.toggle('cd', isCdMode);
-        coverCard.classList.toggle('cd', isCdMode);
-        cdRing.classList.toggle('cd', isCdMode);
+        coverImage?.classList.toggle('cd', isCdMode);
+        coverCard?.classList.toggle('cd', isCdMode);
+        cdRing?.classList.toggle('cd', isCdMode);
 
         await this.updateFullscreenMetadata(track, nextTrack);
 

--- a/styles.css
+++ b/styles.css
@@ -11484,13 +11484,13 @@ body:has(#side-panel.active) #close-fullscreen-cover-btn {
 img.cd {
     border-radius: 50% !important;
     box-shadow: none;
-    clip-path: url("#cd-hole-clip");
+    clip-path: url('#cd-hole-clip');
 }
 
 .fullscreen-artwork-card.cd {
     position: relative;
     border-radius: 50% !important;
-    border: .125vw solid #ccc;
+    border: 0.125vw solid #ccc;
     animation: spin 200s linear infinite;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -11480,3 +11480,32 @@ body:has(#side-panel.active) #close-fullscreen-cover-btn {
     opacity: 0.8;
     vertical-align: middle;
 }
+
+img.cd {
+    border-radius: 50% !important;
+    box-shadow: none;
+    clip-path: url(#cd-hole-clip);
+}
+
+.fullscreen-artwork-card.cd {
+    position: relative;
+    border-radius: 50% !important;
+    border: .125vw solid #ccc;
+    animation: spin 200s linear infinite;
+}
+
+.cd-ring {
+    display: none;
+}
+
+.cd-ring.cd {
+    display: block;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 23.5%;
+    height: 23.5%;
+    border-radius: 50%;
+    border: .125vw solid #ccc;
+}

--- a/styles.css
+++ b/styles.css
@@ -11490,7 +11490,7 @@ img.cd {
 .fullscreen-artwork-card.cd {
     position: relative;
     border-radius: 50% !important;
-    border: .125vw solid #ccc;
+    border: 0.125vw solid #ccc;
     animation: spin 200s linear infinite;
 }
 
@@ -11507,5 +11507,5 @@ img.cd {
     width: 23.5%;
     height: 23.5%;
     border-radius: 50%;
-    border: .125vw solid #ccc;
+    border: 0.125vw solid #ccc;
 }

--- a/styles.css
+++ b/styles.css
@@ -11484,7 +11484,7 @@ body:has(#side-panel.active) #close-fullscreen-cover-btn {
 img.cd {
     border-radius: 50% !important;
     box-shadow: none;
-    clip-path: url(#cd-hole-clip);
+    clip-path: url("#cd-hole-clip");
 }
 
 .fullscreen-artwork-card.cd {

--- a/styles.css
+++ b/styles.css
@@ -11490,11 +11490,11 @@ img.cd {
 .fullscreen-artwork-card.cd {
     position: relative;
     border-radius: 50% !important;
-    border: .125vw solid `#ccc`;
+    border: .125vw solid #ccc;
     animation: spin 200s linear infinite;
 }
 
-`@media` (prefers-reduced-motion: reduce) {
+@media (prefers-reduced-motion: reduce) {
     .fullscreen-artwork-card.cd {
         animation: none;
     }

--- a/styles.css
+++ b/styles.css
@@ -11490,8 +11490,14 @@ img.cd {
 .fullscreen-artwork-card.cd {
     position: relative;
     border-radius: 50% !important;
-    border: 0.125vw solid #ccc;
+    border: .125vw solid `#ccc`;
     animation: spin 200s linear infinite;
+}
+
+`@media` (prefers-reduced-motion: reduce) {
+    .fullscreen-artwork-card.cd {
+        animation: none;
+    }
 }
 
 .cd-ring {


### PR DESCRIPTION
### Description

samidy said it's cool :fire: 
[Screencast From 2026-04-19 21-08-45.webm](https://github.com/user-attachments/assets/7f87c5b4-1edb-48f8-bc8f-d819454cd25e)
if this doesn't embed blame github

### Type of Change

- [ ] Bug fix
- [X] New feature
- [X] Style/UI update
- [ ] Docs only

### Checklist

- [X] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [X] **I understand every line of code I am submitting.**
- [X] I have tested these changes locally, and they work as expected.
- [ ] Is this Pull request Using AI/Is Vibecoded?

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "CD Album Cover" toggle in Settings → Appearance to enable a circular, spinning fullscreen album-art mode with a decorative ring overlay.
  * Setting persists across sessions and is enabled by default.
  * Fullscreen artwork now shows a circular mask and long-duration spin; motion respects users' reduced-motion preference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->