### PR TITLE
Replace tidal-uptime workers.dev URLs with geeked.wtf

### DIFF
--- a/INSTANCES.md
+++ b/INSTANCES.md
@@ -24,8 +24,7 @@ PLEASE do not use any rehost of monochrome and complain to us about features not
 
 Monochrome uses the Hi-Fi API under the hood. Live, up-to-date status trackers (which return JSON) can be found below:
 
-- [https://tidal-uptime.jiffy-puffs-1j.workers.dev](https://tidal-uptime.jiffy-puffs-1j.workers.dev/)
-- [https://tidal-uptime.props-76styles.workers.dev](https://tidal-uptime.props-76styles.workers.dev/)
+- [https://tidal-uptime.geeked.wtf](https://tidal-uptime.geeked.wtf)
 
 These are available API endpoints that can be used with Monochrome or other Hi-Fi based applications:
 

--- a/functions/album/[id].js
+++ b/functions/album/[id].js
@@ -48,8 +48,7 @@ class TidalAPI {
 class ServerAPI {
     constructor() {
         this.INSTANCES_URLS = [
-            'https://tidal-uptime.jiffy-puffs-1j.workers.dev/',
-            'https://tidal-uptime.props-76styles.workers.dev/',
+            'https://tidal-uptime.geeked.wtf',
         ];
         this.apiInstances = null;
     }

--- a/functions/artist/[id].js
+++ b/functions/artist/[id].js
@@ -48,8 +48,7 @@ class TidalAPI {
 class ServerAPI {
     constructor() {
         this.INSTANCES_URLS = [
-            'https://tidal-uptime.jiffy-puffs-1j.workers.dev/',
-            'https://tidal-uptime.props-76styles.workers.dev/',
+            'https://tidal-uptime.geeked.wtf',
         ];
         this.apiInstances = null;
     }

--- a/functions/playlist/[id].js
+++ b/functions/playlist/[id].js
@@ -48,8 +48,7 @@ class TidalAPI {
 class ServerAPI {
     constructor() {
         this.INSTANCES_URLS = [
-            'https://tidal-uptime.jiffy-puffs-1j.workers.dev/',
-            'https://tidal-uptime.props-76styles.workers.dev/',
+            'https://tidal-uptime.geeked.wtf',
         ];
         this.apiInstances = null;
     }

--- a/functions/track/[id].js
+++ b/functions/track/[id].js
@@ -70,8 +70,7 @@ class TidalAPI {
 class ServerAPI {
     constructor() {
         this.INSTANCES_URLS = [
-            'https://tidal-uptime.jiffy-puffs-1j.workers.dev/',
-            'https://tidal-uptime.props-76styles.workers.dev/',
+            'https://tidal-uptime.geeked.wtf',
         ];
         this.apiInstances = null;
     }

--- a/js/storage.js
+++ b/js/storage.js
@@ -5,8 +5,7 @@ import { SVG_RIGHT_ARROW } from './icons';
 export const apiSettings = {
     STORAGE_KEY: 'monochrome-api-instances-v9',
     INSTANCES_URLS: [
-        'https://tidal-uptime.jiffy-puffs-1j.workers.dev/',
-        'https://tidal-uptime.props-76styles.workers.dev/',
+        'https://tidal-uptime.geeked.wtf',
     ],
     defaultInstances: { api: [], streaming: [] },
     userInstances: null,


### PR DESCRIPTION
## Summary

- Replaced `https://tidal-uptime.jiffy-puffs-1j.workers.dev/` and `https://tidal-uptime.props-76styles.workers.dev/` with `https://tidal-uptime.geeked.wtf` across all files
- Affected files: `js/storage.js`, `functions/artist/[id].js`, `functions/album/[id].js`, `functions/track/[id].js`, `functions/playlist/[id].js`, `INSTANCES.md`

## Test plan

- [ ] Verify instance health checks resolve correctly against the new URL
- [ ] Confirm API instance loading works as expected in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated backend infrastructure by unifying multiple proxy and uptime tracking service endpoints into a single centralized endpoint across all metadata operations, enhancing overall system reliability and redundancy, reducing operational complexity, and streamlining ongoing service maintenance and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->