### PR TITLE
fix(hifi): use Tidal v2 API for artist biography

### DIFF
--- a/js/HiFi.ts
+++ b/js/HiFi.ts
@@ -1026,6 +1026,8 @@ interface JsonApiIncludeAttributes {
     albumType?: string;
     createdAt?: string;
     type?: string;
+    text?: string;
+    source?: string;
 }
 
 /** An included resource node from a TIDAL OpenAPI JSON:API response. */
@@ -1933,14 +1935,34 @@ class HiFiClient {
         return HiFiClient.#jsonResponse({ version: HiFiClient.API_VERSION, albums: page_data, tracks });
     }
     async getArtistBiography(artistId: number, signal?: AbortSignal): Promise<TidalResponse<ArtistBioResponse>> {
-        const url = `https://api.tidal.com/v1/artists/${artistId}/bio`;
-        const params = {
-            locale: this.#locale,
-            countryCode: this.#countryCode,
-        };
-        const data = await this.#fetchJson<ArtistBiography>(url, params, signal);
+        const url = `https://openapi.tidal.com/v2/artists/${artistId}`;
+        const payload = await this.#fetchJson<{ data?: JsonApiInclude; included?: JsonApiInclude[] }>(
+            url,
+            { countryCode: this.#countryCode, include: 'biography' },
+            signal
+        );
 
-        return HiFiClient.#jsonResponse({ version: HiFiClient.API_VERSION, data: data });
+        const includedMap = new Map<string, JsonApiInclude>();
+        for (const item of payload?.included ?? []) {
+            includedMap.set(`${item.type}:${item.id}`, item);
+        }
+
+        const bioRelData = payload?.data?.relationships?.biography?.data;
+        const bioRef = (Array.isArray(bioRelData) ? bioRelData[0] : bioRelData) as JsonApiRef | undefined;
+        const bioItem = bioRef
+            ? (includedMap.get(`${bioRef.type}:${bioRef.id}`) ??
+               includedMap.get(`biographies:${bioRef.id}`) ??
+               includedMap.get(`biography:${bioRef.id}`))
+            : undefined;
+
+        const data: ArtistBiography = {
+            text: bioItem?.attributes?.text ?? '',
+            source: bioItem?.attributes?.source ?? 'Tidal',
+            lastUpdated: '',
+            summary: '',
+        };
+
+        return HiFiClient.#jsonResponse({ version: HiFiClient.API_VERSION, data });
     }
 
     #buildCoverEntry(cover_slug: string, name?: string | null, track_id?: number | null): CoverEntry {


### PR DESCRIPTION
## Problem

Artist biography lookups were returning 404. The `/artist/bio` route in `HiFi.ts` was calling the Tidal v1 endpoint:

```
https://api.tidal.com/v1/artists/{id}/bio
```

This endpoint is no longer functional and returns 404.

The root cause trail:
- Daniel (`a282b37`, 2026-03-27) introduced the `/artist/bio` proxy route using this v1 endpoint
- Daniel (`00efcb8`, 2026-04-18) later fixed it properly by switching to the v2 OpenAPI API with `include=biography`
- Samidy (`b528720`, 2026-04-19) reverted that v2 fix, leaving the broken v1 endpoint in place

## Fix

Switch `getArtistBiography` to the Tidal v2 OpenAPI endpoint:

```
https://openapi.tidal.com/v2/artists/{id}?include=biography
```

The biography is returned as a sideloaded resource in the JSON:API `included` array. The implementation builds an `includedMap` keyed by `type:id` and resolves the bio ref from `data.relationships.biography.data`, trying a few type name variants (`biography`, `biographies`) to handle Tidal's inconsistent naming across endpoints.

Also restores `text` and `source` on `JsonApiIncludeAttributes`, which were stripped by the same revert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated artist biography data retrieval to use a current data source with improved data structure handling.
  * Modified default values for biography metadata fields (lastUpdated and summary now default to empty strings; source defaults to 'Tidal').

<!-- end of auto-generated comment: release notes by coderabbit.ai -->