### PR TITLE
chore(docker): fix build context and lockfile path after root debloat

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ We had to heavily customize the authentication system and write several custom s
 
 ```bash
 git clone https://github.com/monochrome-music/monochrome.git
-cd monochrome
+cd monochrome/docker
 docker compose up -d
 ```
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ ARG POCKETBASE_URL
 ARG SESSION_MAX_AGE
 
 # Copy package files first for caching
-COPY package.json package-lock.json ./
+COPY package.json bun.lock ./
 
 # Install dependencies (Node)
 RUN bun install

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,8 +2,8 @@ services:
     # Production frontend -- always runs
     monochrome:
         build:
-            context: .
-            dockerfile: Dockerfile
+            context: ..
+            dockerfile: docker/Dockerfile
             args:
                 - AUTH_ENABLED=${AUTH_ENABLED}
                 - AUTH_SECRET=${AUTH_SECRET}
@@ -54,15 +54,15 @@ services:
     # Development server -- only starts with: docker compose --profile dev up -d
     monochrome-dev:
         build:
-            context: .
-            dockerfile: Dockerfile.dev
+            context: ..
+            dockerfile: docker/Dockerfile.dev
         container_name: monochrome-dev
         profiles:
             - dev
         ports:
             - '${MONOCHROME_DEV_PORT:-5173}:5173'
         volumes:
-            - .:/app
+            - ..:/app
             - /app/node_modules
         command: npm run dev -- --host 0.0.0.0
         networks:


### PR DESCRIPTION
the [11f66c1 "debloat root"](https://github.com/monochrome-music/monochrome/commit/11f66c1a28d9d13b54545b5224344c621d3fa8c9) move relocated the dockerfiles and compose file into docker/ but left build paths pointing at the old layout, so `docker compose up -d` failed to find nginx.conf.

- set `context: ..` and `dockerfile: docker/...` on the monochrome and monochrome-dev services, and bind-mount `..:/app` in dev so the build and runtime context is the repo root
- copy `bun.lock` instead of the non-existent `package-lock.json` for the dependency-cache layer

- fix readme instructions to spin up docker compose from new location.

### Description

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist

- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.
- [ ] Is this Pull request Using AI/Is Vibecoded?

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker self-hosting quick-start instructions to navigate to the correct working directory when starting the Docker Compose stack
  * Improved Docker build configuration to properly align with Bun package manager for better dependency caching
  * Updated Docker Compose build contexts and source mount paths for consistency across production and development services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->