### PR TITLE
feat(api): add multi-instance Qobuz support with failover

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -1637,43 +1637,73 @@ export class LosslessAPI {
     }
 
     async getQobuzStreamUrl(isrc, quality = 'LOSSLESS') {
+        let qobuzInstances = [];
         try {
-            const trackRes = await fetch(`https://qobuz.kennyy.com.br/api/get-music?q=${isrc}&offset=0`);
-            const trackJson = await trackRes.json();
+            qobuzInstances = await this.settings.getInstances('qobuz');
+        } catch {
+            // ignore
+        }
 
-            const tracks = trackJson.data?.tracks?.items || [];
-            const match = tracks.find((t) => t.isrc?.toLowerCase() === isrc.toLowerCase()) || tracks[0];
+        if (!qobuzInstances || qobuzInstances.length === 0) {
+            return null;
+        }
 
-            if (match && match.id) {
-                const qobuzTrackId = match.id;
-                const qobuzQualityMap = {
-                    HI_RES_LOSSLESS: '27',
-                    LOSSLESS: '7',
-                    HIGH: '6',
-                    LOW: '5',
-                };
-                const qobuzQuality = qobuzQualityMap[quality] || '7';
+        for (const instance of qobuzInstances) {
+            const rawUrl = typeof instance === 'string' ? instance : instance?.url;
+            if (!rawUrl || typeof rawUrl !== 'string') continue;
+            const baseUrl = rawUrl.replace(/\/+$/, '');
+            try {
+                const controller = new AbortController();
+                const timeoutId = setTimeout(() => controller.abort(), 8000);
 
-                const streamRes = await fetch(
-                    `https://qobuz.kennyy.com.br/api/download-music?track_id=${qobuzTrackId}&quality=${qobuzQuality}`
-                );
-                const streamJson = await streamRes.json();
+                const trackRes = await fetch(`${baseUrl}/api/get-music?q=${encodeURIComponent(isrc)}&offset=0`, {
+                    signal: controller.signal,
+                });
+                clearTimeout(timeoutId);
+                if (!trackRes.ok) continue;
+                const trackJson = await trackRes.json();
 
-                if (streamJson.success && streamJson.data && streamJson.data.url) {
-                    let rgInfo = null;
-                    if (match.audio_info) {
-                        rgInfo = {
-                            trackReplayGain: match.audio_info.replaygain_track_gain,
-                            trackPeakAmplitude: match.audio_info.replaygain_track_peak,
-                            albumReplayGain: match.audio_info.replaygain_album_gain,
-                            albumPeakAmplitude: match.audio_info.replaygain_album_peak,
-                        };
+                const tracks = trackJson.data?.tracks?.items || [];
+                const match = tracks.find((t) => t.isrc?.toLowerCase() === isrc.toLowerCase()) || tracks[0];
+
+                if (match && match.id) {
+                    const qobuzTrackId = match.id;
+                    const qobuzQualityMap = {
+                        HI_RES_LOSSLESS: '27',
+                        LOSSLESS: '7',
+                        HIGH: '6',
+                        LOW: '5',
+                    };
+                    const qobuzQuality = qobuzQualityMap[quality] || '7';
+
+                    const streamController = new AbortController();
+                    const streamTimeoutId = setTimeout(() => streamController.abort(), 8000);
+
+                    const streamRes = await fetch(
+                        `${baseUrl}/api/download-music?track_id=${qobuzTrackId}&quality=${qobuzQuality}`,
+                        { signal: streamController.signal }
+                    );
+                    clearTimeout(streamTimeoutId);
+                    if (!streamRes.ok) continue;
+                    const streamJson = await streamRes.json();
+
+                    if (streamJson.success && streamJson.data && streamJson.data.url) {
+                        let rgInfo = null;
+                        if (match.audio_info) {
+                            rgInfo = {
+                                trackReplayGain: match.audio_info.replaygain_track_gain,
+                                trackPeakAmplitude: match.audio_info.replaygain_track_peak,
+                                albumReplayGain: match.audio_info.replaygain_album_gain,
+                                albumPeakAmplitude: match.audio_info.replaygain_album_peak,
+                            };
+                        }
+                        return { url: streamJson.data.url, rgInfo };
                     }
-                    return { url: streamJson.data.url, rgInfo };
                 }
+            } catch (e) {
+                console.warn(`Qobuz instance ${baseUrl} failed for ISRC ${isrc}:`, e);
+                continue;
             }
-        } catch (e) {
-            console.error('Failed to resolve ISRC:', isrc, e);
         }
         return null;
     }

--- a/js/storage.js
+++ b/js/storage.js
@@ -7,7 +7,7 @@ export const apiSettings = {
     INSTANCES_URLS: [
         'https://tidal-uptime.geeked.wtf',
     ],
-    defaultInstances: { api: [], streaming: [] },
+    defaultInstances: { api: [], streaming: [], qobuz: [] },
     userInstances: null,
     instancesLoaded: false,
     _loadPromise: null,
@@ -16,9 +16,11 @@ export const apiSettings = {
         if (this.userInstances) return this.userInstances;
         try {
             const stored = localStorage.getItem('monochrome-user-api-instances-v1');
-            this.userInstances = stored ? JSON.parse(stored) : { api: [], streaming: [] };
+            const parsed = stored ? JSON.parse(stored) : { api: [], streaming: [], qobuz: [] };
+            if (!parsed.qobuz) parsed.qobuz = [];
+            this.userInstances = parsed;
         } catch {
-            this.userInstances = { api: [], streaming: [] };
+            this.userInstances = { api: [], streaming: [], qobuz: [] };
         }
         return this.userInstances;
     },
@@ -96,13 +98,16 @@ export const apiSettings = {
                         { url: 'https://hund.qqdl.site', version: '2.6' },
                         { url: 'https://wolf.qqdl.site', version: '2.6' },
                     ],
+                    qobuz: [
+                        { url: 'https://qobuz.kennyy.com.br', version: '1.0' },
+                    ],
                 };
                 this.instancesLoaded = true;
                 this._loadPromise = null;
                 return this.defaultInstances;
             }
 
-            let groupedInstances = { api: [], streaming: [] };
+            let groupedInstances = { api: [], streaming: [], qobuz: [] };
 
             const isBlockedInstance = (item) => {
                 const url = typeof item === 'string' ? item : item.url;
@@ -117,6 +122,17 @@ export const apiSettings = {
                 groupedInstances.streaming = data.streaming.filter((item) => !isBlockedInstance(item));
             } else if (groupedInstances.api.length > 0) {
                 groupedInstances.streaming = [...groupedInstances.api];
+            }
+
+            if (data.qobuz && Array.isArray(data.qobuz)) {
+                groupedInstances.qobuz = data.qobuz;
+            }
+
+            // Ensure default Qobuz instance is always available
+            if (groupedInstances.qobuz.length === 0) {
+                groupedInstances.qobuz = [
+                    { url: 'https://qobuz.kennyy.com.br', version: '1.0' },
+                ];
             }
 
             this.defaultInstances = groupedInstances;
@@ -221,6 +237,10 @@ export const apiSettings = {
 
         if (instances.streaming && instances.streaming.length) {
             instances.streaming = prioritySort([...instances.streaming]);
+        }
+
+        if (instances.qobuz && instances.qobuz.length) {
+            instances.qobuz = shuffle([...instances.qobuz]);
         }
 
         this.saveInstances(instances);

--- a/js/ui.js
+++ b/js/ui.js
@@ -6033,12 +6033,23 @@ export class UIRenderer {
 
     renderApiSettings() {
         const container = document.getElementById('api-instance-list');
-        Promise.all([this.api.settings.getInstances('api'), this.api.settings.getInstances('streaming')])
-            .then(([apiInstances, streamingInstances]) => {
+        Promise.allSettled([
+            this.api.settings.getInstances('api'),
+            this.api.settings.getInstances('streaming'),
+            this.api.settings.getInstances('qobuz'),
+        ])
+            .then((results) => {
+                const apiInstances = results[0].status === 'fulfilled' ? results[0].value : [];
+                const streamingInstances = results[1].status === 'fulfilled' ? results[1].value : [];
+                const qobuzInstances = results[2].status === 'fulfilled' ? results[2].value : [];
                 const renderGroup = (instances, type) => {
-                    if (!instances || instances.length === 0) return '';
+                    const groupLabels = {
+                        api: 'API Instances',
+                        streaming: 'Streaming Instances',
+                        qobuz: 'Qobuz Instances',
+                    };
 
-                    const listHtml = instances
+                    const listHtml = (instances || [])
                         .map((instance, index) => {
                             const isObject = instance && typeof instance === 'object';
                             const instanceUrl = isObject ? instance.url || '' : String(instance || '');
@@ -6075,7 +6086,7 @@ export class UIRenderer {
 
                     return `
                     <li class="group-header" style="display: flex; justify-content: space-between; align-items: center; font-weight: bold; padding: 1rem 0 0.5rem; background: transparent; border: none;">
-                        <span>${type === 'api' ? 'API Instances' : 'Streaming Instances'}</span>
+                        <span>${groupLabels[type] || type + ' Instances'}</span>
                         <button class="add-instance" data-type="${type}" title="Add Custom Instance" style="background: var(--primary); color: var(--primary-foreground); border: none; padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.75rem; cursor: pointer; pointer-events: auto;">
                             Add
                         </button>
@@ -6084,7 +6095,10 @@ export class UIRenderer {
                 `;
                 };
 
-                container.innerHTML = renderGroup(apiInstances, 'api') + renderGroup(streamingInstances, 'streaming');
+                container.innerHTML =
+                    renderGroup(apiInstances, 'api') +
+                    (streamingInstances && streamingInstances.length > 0 ? renderGroup(streamingInstances, 'streaming') : '') +
+                    renderGroup(qobuzInstances, 'qobuz');
 
                 const stats = this.api.getCacheStats();
                 const cacheInfo = document.getElementById('cache-info');


### PR DESCRIPTION
## Description
Adds support for multiple Qobuz API instances with automatic failover, replacing the previous hardcoded single-URL approach.

## Type of Change
- [x] New feature

## What Changed

### js/storage.js
- Added qobuz as a new instance type alongside api and streaming
- Default Qobuz instance: qobuz.kennyy.com.br
- When the uptime API does not return Qobuz instances, defaults are injected automatically
- Users can add/remove custom Qobuz instances via Settings
- Qobuz instances are shuffled on refresh for load distribution

### js/api.js
- getQobuzStreamUrl() now fetches instances from settings.getInstances('qobuz') instead of using a hardcoded URL
- Iterates through all configured instances with automatic failover (if one fails, tries the next)
- ISRC parameter is now properly URI-encoded via encodeURIComponent()
- Returns null if no Qobuz instances are configured (clean fallback to Tidal)

### js/ui.js
- renderApiSettings() now displays a Qobuz Instances section in Settings alongside API and Streaming instances
- Supports the same Add/Delete functionality as other instance types
- Streaming Instances section only renders when instances are available

## Checklist
- [x] I have read the Contributing Guidelines.
- [x] I understand every line of code I am submitting.
- [x] I have tested these changes locally, and they work as expected.
- [x] Is this Pull request Using AI/Is Vibecoded?

AI was used as a tool to help implement and refactor the code. All changes were reviewed and tested manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for configuring multiple Qobuz instances.
  * Settings UI shows and manages Qobuz instances alongside other services.
* **Improvements**
  * Streaming now tries configured Qobuz sources in sequence with per-source timeouts and continues on failures for automatic failover.
  * Instance lists are randomized and migrated safely from older settings.
* **Bug Fixes**
  * UI rendering no longer aborts when a provider request fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->