### PR TITLE
fix(download): transcode lossless source to AAC when lossy quality is requested

### DIFF
--- a/js/download-utils.ts
+++ b/js/download-utils.ts
@@ -9,7 +9,7 @@ import {
     getContainerFormat,
     transcodeWithContainerFormat,
 } from './ffmpegFormats';
-import { ffmpegInfo, ffmpegNewContainer } from './ffmpeg';
+import { ffmpegInfo, ffmpegNewContainer, ffmpeg } from './ffmpeg';
 
 /**
  * Triggers a browser file download for the given blob.
@@ -110,6 +110,29 @@ export async function applyAudioPostProcessing(
                 }
                 throw encodingError;
             }
+        }
+    }
+
+    // Source is lossless but user requested lossy quality (HIGH/LOW).
+    // This can happen when Qobuz returns FLAC regardless of the quality param.
+    // Transcode to AAC to match expected lossy output.
+    if (sourceIsLossless && !statedLossless && !isCustomFormat(quality)) {
+        try {
+            const bitrateMap: Record<string, string> = { HIGH: '256k', LOW: '96k' };
+            const bitrate = bitrateMap[quality] || '256k';
+            blob = await ffmpeg(blob, {
+                args: ['-map_metadata', '-1', '-c:a', 'aac', '-b:a', bitrate],
+                outputName: 'output.m4a',
+                outputMime: 'audio/mp4',
+                onProgress,
+                signal,
+            });
+            return blob;
+        } catch (error) {
+            if ((error as Error)?.name === 'AbortError' || signal?.aborted) {
+                throw error;
+            }
+            console.warn('Lossy transcode failed, returning lossless source:', error);
         }
     }
 


### PR DESCRIPTION
## Problem

When the stream source returns FLAC regardless of the requested quality (e.g. Qobuz always serves lossless), downloads with lossy quality settings (HIGH/LOW) are incorrectly saved as FLAC files instead of being transcoded to the expected lossy format.

All downloads end up as FLAC no matter what download option is picked.

## Root Cause

In \download-utils.ts\, \pplyAudioPostProcessing()\ handled two cases:

1. **Custom ffmpeg formats** (MP3, OGG, AAC custom) — detected via \isCustomFormat(quality)\ → transcoded correctly
2. **Lossless container conversion** — detected via \statedLossless\ → remuxed/rebuilt correctly

But there was a **missing third case**: source is lossless (FLAC), user wants standard lossy quality (HIGH or LOW). Since:
- \isCustomFormat('HIGH')\ = false → skipped
- \statedLossless\ = false (HIGH doesn't end in LOSSLESS) → skipped
- Result: FLAC blob returned as-is

## Fix

Added a new code path after the custom format block that detects the mismatch (\sourceIsLossless && !statedLossless && !isCustomFormat(quality)\) and transcodes to AAC at the appropriate bitrate:
- HIGH → AAC 256kbps
- LOW → AAC 96kbps

Falls back gracefully to the lossless source if transcoding fails.

## Changes

- **js/download-utils.ts**: Added \fmpeg\ import, added lossy transcode block for lossless→lossy mismatch.

> This PR was authored with AI assistance (GitHub Copilot).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced audio conversion handling for lossless to lossy format conversions with automatic fallback behavior.
  * Improved error handling during format conversions to gracefully handle conversion failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->