### PR TITLE
fix(android): update Manifest permissions for modern Android (API 33+) and remove dead service

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -34,6 +34,7 @@
     <!-- Permissions -->
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
         android:allowBackup="true"
@@ -20,24 +20,22 @@
             </intent-filter>
         </activity>
 
-        <service
-            android:name=".AudioPlaybackService"
-            android:foregroundServiceType="mediaPlayback"
-            android:exported="false" />
-
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
-            <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/file_paths" />
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
         </provider>
     </application>
 
     <!-- Permissions -->
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
 </manifest>


### PR DESCRIPTION
### Description
This PR fixes app crashes and local media loading issues on modern Android devices (specifically tested on Android 16 / Realme 13 5G).

Changes included in `AndroidManifest.xml`:
1. **Removed `.AudioPlaybackService`:** The manifest referenced a non-existent native service, which caused a `ClassNotFoundException` during build and runtime.
2. **Added `READ_MEDIA_AUDIO`:** This is strictly required for Android 13+ (API 33+) to read local audio files, replacing old external storage permissions. Without it, the app silently fails to load music.
3. **Added `POST_NOTIFICATIONS`:** Required for Android 13+ to display media playback controls in the notification drawer.
4. **Kept `FOREGROUND_SERVICE` and `FOREGROUND_SERVICE_MEDIA_PLAYBACK`:** Ensures the app handles background media playback correctly without being killed by the system on newer Android versions.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist

- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.
- [ ] Is this Pull request Using AI/Is Vibecoded? No.

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android app manifest with new permissions to support push notifications and audio file access
  * Enhanced file provider configuration for improved file handling capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->