### PR TITLE
fix missing album art in downloads

### DIFF
--- a/INSTANCES.md
+++ b/INSTANCES.md
@@ -1,7 +1,6 @@
 > [!important]
 > April 30th, 2026: this file is currently outdated, as we have switched away from hifi-api (kinda), however were lowk too lazy right now, though it will be updated soon.
 
-
 # Monochrome Instances
 
 This document lists public instances of Monochrome that you can use. Instances are community-hosted versions of Monochrome that provide access to the application.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
- 
  <p align="center">
   <a href="https://monochrome.tf">
     <img src="https://github.com/monochrome-music/monochrome/blob/main/public/assets/512.png?raw=true" alt="Monochrome Logo" width="150px">

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "@svta/common-media-library": "^0.18.1",
         "@types/wicg-file-system-access": "^2023.10.7",
         "@typescript-eslint/eslint-plugin": "^8.57.2",
-        "@uimaxbai/am-lyrics": "^1.2.8",
+        "@uimaxbai/am-lyrics": "^1.4.1",
         "@vitest/web-worker": "^4.1.2",
         "appwrite": "^23.0.0",
         "butterchurn": "^2.6.7",
@@ -678,7 +678,7 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.58.0", "", { "dependencies": { "@typescript-eslint/types": "8.58.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ=="],
 
-    "@uimaxbai/am-lyrics": ["@uimaxbai/am-lyrics@1.2.8", "", { "dependencies": { "@babel/runtime": "^7.27.6", "lit": "^3.1.4" }, "peerDependencies": { "@lit/react": "^1.0.0", "react": ">=17.0.0" }, "optionalPeers": ["@lit/react", "react"] }, "sha512-aR8kxqIYcVlsMCH6bbH8ANG+bN/2OAw66ZFjYD1a25hkMTyxtULWgWwAZlUfreP9V47bFvNgXIKvOqhO5JFpeg=="],
+    "@uimaxbai/am-lyrics": ["@uimaxbai/am-lyrics@1.4.1", "", { "dependencies": { "@babel/runtime": "^7.27.6", "lit": "^3.1.4" }, "peerDependencies": { "@lit/react": "^1.0.0", "react": ">=17.0.0" }, "optionalPeers": ["@lit/react", "react"] }, "sha512-3oEAJzDhC7WqeAIDodEj+ZujtIogCXGtmCrl2wAhuQVSQP2iMjR3OL7ZWx/boC5BdIMfHqV8ucEFoeM1G9Ye8w=="],
 
     "@vitest/browser": ["@vitest/browser@4.1.2", "", { "dependencies": { "@blazediff/core": "1.9.1", "@vitest/mocker": "4.1.2", "@vitest/utils": "4.1.2", "magic-string": "^0.30.21", "pngjs": "^7.0.0", "sirv": "^3.0.2", "tinyrainbow": "^3.1.0", "ws": "^8.19.0" }, "peerDependencies": { "vitest": "4.1.2" } }, "sha512-CwdIf90LNf1Zitgqy63ciMAzmyb4oIGs8WZ40VGYrWkssQKeEKr32EzO8MKUrDPPcPVHFI9oQ5ni2Hp24NaNRQ=="],
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -3,7 +3,8 @@
 While the website works without the extension with the use of proxies, it is recommended to install it to prevent various annoying issues. The website works best with the extension on.
 
 ## What it does
-It makes your `requestHeaders` appear to come from Tidal, which can result in fewer blocked requests.  
+
+It makes your `requestHeaders` appear to come from Tidal, which can result in fewer blocked requests.
 
 ## Installation
 

--- a/functions/album/[id].js
+++ b/functions/album/[id].js
@@ -48,9 +48,7 @@ class TidalAPI {
 
 class ServerAPI {
     constructor() {
-        this.INSTANCES_URLS = [
-            'https://tidal-uptime.geeked.wtf',
-        ];
+        this.INSTANCES_URLS = ['https://tidal-uptime.geeked.wtf'];
         this.apiInstances = null;
     }
 

--- a/functions/artist/[id].js
+++ b/functions/artist/[id].js
@@ -48,9 +48,7 @@ class TidalAPI {
 
 class ServerAPI {
     constructor() {
-        this.INSTANCES_URLS = [
-            'https://tidal-uptime.geeked.wtf',
-        ];
+        this.INSTANCES_URLS = ['https://tidal-uptime.geeked.wtf'];
         this.apiInstances = null;
     }
 

--- a/functions/playlist/[id].js
+++ b/functions/playlist/[id].js
@@ -48,9 +48,7 @@ class TidalAPI {
 
 class ServerAPI {
     constructor() {
-        this.INSTANCES_URLS = [
-            'https://tidal-uptime.geeked.wtf',
-        ];
+        this.INSTANCES_URLS = ['https://tidal-uptime.geeked.wtf'];
         this.apiInstances = null;
     }
 

--- a/functions/track/[id].js
+++ b/functions/track/[id].js
@@ -70,9 +70,7 @@ class TidalAPI {
 
 class ServerAPI {
     constructor() {
-        this.INSTANCES_URLS = [
-            'https://tidal-uptime.geeked.wtf',
-        ];
+        this.INSTANCES_URLS = ['https://tidal-uptime.geeked.wtf'];
         this.apiInstances = null;
     }
 

--- a/index.html
+++ b/index.html
@@ -1752,7 +1752,8 @@
                         </nav>
 
                         <div class="sidebar-nav-bottom">
-                            <nav class="sidebar-nav bottom">                                <ul>
+                            <nav class="sidebar-nav bottom">
+                                <ul>
                                     <li class="nav-item" id="sidebar-nav-about-bottom">
                                         <a href="/about">
                                             <use svg="!lucide/info.svg" size="24" />
@@ -5328,7 +5329,7 @@
                                     <select id="lossless-container-setting">
                                         <option value="nochange">Don't change</option>
                                     </select>
-                                </div>                            
+                                </div>
                             </div>
                             <div class="settings-group">
                                 <div class="setting-item">

--- a/js/HiFi.test.ts
+++ b/js/HiFi.test.ts
@@ -129,7 +129,11 @@ test('Fetch artist info', async () => {
     await checkRoute(
         `/artist/?id=${ARTIST_ID}`,
         () => instance.getArtist(ARTIST_ID),
-        async (info: { cover: string; tracks: Array<{ duration?: number }>; albums: { items: Array<{ duration?: number }> } }) => {
+        async (info: {
+            cover: string;
+            tracks: Array<{ duration?: number }>;
+            albums: { items: Array<{ duration?: number }> };
+        }) => {
             expect(info).toHaveProperty('cover');
             expect(info.cover).not.toBeUndefined();
 

--- a/js/HiFi.ts
+++ b/js/HiFi.ts
@@ -1789,7 +1789,7 @@ class HiFiClient {
                 if (!iso || typeof iso !== 'string') return undefined;
                 const m = iso.match(/^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/);
                 if (!m || (!m[1] && !m[2] && !m[3])) return undefined;
-                return (parseInt(m[1] || '0', 10) * 3600) + (parseInt(m[2] || '0', 10) * 60) + parseInt(m[3] || '0', 10);
+                return parseInt(m[1] || '0', 10) * 3600 + parseInt(m[2] || '0', 10) * 60 + parseInt(m[3] || '0', 10);
             };
 
             const albums: any[] = [];
@@ -1956,11 +1956,11 @@ class HiFiClient {
         }
 
         const bioRelData = payload?.data?.relationships?.biography?.data;
-        const bioRef = (Array.isArray(bioRelData) ? bioRelData[0] : bioRelData) as JsonApiRef | undefined;
+        const bioRef = Array.isArray(bioRelData) ? bioRelData[0] : bioRelData;
         const bioItem = bioRef
             ? (includedMap.get(`${bioRef.type}:${bioRef.id}`) ??
-               includedMap.get(`biographies:${bioRef.id}`) ??
-               includedMap.get(`biography:${bioRef.id}`))
+              includedMap.get(`biographies:${bioRef.id}`) ??
+              includedMap.get(`biography:${bioRef.id}`))
             : undefined;
 
         const data: ArtistBiography = {

--- a/js/api.js
+++ b/js/api.js
@@ -436,9 +436,7 @@ export class LosslessAPI {
         const chunkSize = 5;
         for (let i = 0; i < limitedIds.length; i += chunkSize) {
             const chunk = limitedIds.slice(i, i + chunkSize);
-            const results = await Promise.allSettled(
-                chunk.map((id) => this.getArtist(id, { lightweight: true }))
-            );
+            const results = await Promise.allSettled(chunk.map((id) => this.getArtist(id, { lightweight: true })));
             for (let j = 0; j < results.length; j++) {
                 const r = results[j];
                 if (r.status === 'fulfilled' && r.value?.picture) {

--- a/js/api.js
+++ b/js/api.js
@@ -1960,7 +1960,7 @@ export class LosslessAPI {
             });
         }
 
-        if (track.album?.id && (track.album?.totalDiscs == null || track.album?.numberOfTracksOnDisc == null || !enrichedTrack.album?.cover)) {
+        if (track.album?.id && (track.album?.totalDiscs == null || track.album?.numberOfTracksOnDisc == null || !track.album?.cover)) {
             try {
                 const albumData = await this.getAlbum(track.album.id);
                 enrichedTrack.album = new EnrichedAlbum({

--- a/js/api.js
+++ b/js/api.js
@@ -1963,6 +1963,9 @@ export class LosslessAPI {
                 enrichedTrack.album = new EnrichedAlbum({
                     ...albumData.album,
                     ...enrichedTrack.album,
+                    // Preserve the full album's cover when the track's album cover is null/undefined,
+                    // since some API responses omit or null-out cover in the track's album sub-object.
+                    cover: enrichedTrack.album?.cover || albumData.album?.cover,
                 });
 
                 if (albumData.tracks?.length > 0) {

--- a/js/api.js
+++ b/js/api.js
@@ -1960,7 +1960,10 @@ export class LosslessAPI {
             });
         }
 
-        if (track.album?.id && (track.album?.totalDiscs == null || track.album?.numberOfTracksOnDisc == null || !track.album?.cover)) {
+        if (
+            track.album?.id &&
+            (track.album?.totalDiscs == null || track.album?.numberOfTracksOnDisc == null || !track.album?.cover)
+        ) {
             try {
                 const albumData = await this.getAlbum(track.album.id);
                 enrichedTrack.album = new EnrichedAlbum({

--- a/js/api.js
+++ b/js/api.js
@@ -940,7 +940,12 @@ export class LosslessAPI {
 
         tracks = tracks.map((t) => {
             if (t.album) {
-                t.album = new TrackAlbum(t.album);
+                // Propagate the parent album's cover to each track's album sub-object when
+                // the API omits it in the per-track album object (common for album endpoints).
+                t.album = new TrackAlbum({
+                    ...t.album,
+                    cover: t.album.cover || album.cover,
+                });
             }
 
             return new Track(t);
@@ -1955,7 +1960,7 @@ export class LosslessAPI {
             });
         }
 
-        if (track.album?.id && (track.album?.totalDiscs == null || track.album?.numberOfTracksOnDisc == null)) {
+        if (track.album?.id && (track.album?.totalDiscs == null || track.album?.numberOfTracksOnDisc == null || !enrichedTrack.album?.cover)) {
             try {
                 const albumData = await this.getAlbum(track.album.id);
                 enrichedTrack.album = new EnrichedAlbum({

--- a/js/db.js
+++ b/js/db.js
@@ -469,7 +469,9 @@ export class MusicDatabase {
             ].every((arr) => !arr || (Array.isArray(arr) ? arr.length === 0 : Object.keys(arr).length === 0));
 
             if (allEmpty) {
-                console.warn('[importData] Aborting: clear=true but all import data is empty. Existing data preserved.');
+                console.warn(
+                    '[importData] Aborting: clear=true but all import data is empty. Existing data preserved.'
+                );
                 return false;
             }
         }

--- a/js/download-utils.ts
+++ b/js/download-utils.ts
@@ -118,7 +118,7 @@ export async function applyAudioPostProcessing(
     // Transcode to AAC to match expected lossy output.
     if (sourceIsLossless && !statedLossless && !isCustomFormat(quality)) {
         try {
-            const bitrateMap: Record<string, string> = {HIGH: '320k', FFMPEG_AAC_256: '256k', LOW: '96k' };
+            const bitrateMap: Record<string, string> = { HIGH: '320k', FFMPEG_AAC_256: '256k', LOW: '96k' };
             const bitrate = bitrateMap[quality] || '256k';
             blob = await ffmpeg(blob, {
                 args: ['-map_metadata', '-1', '-c:a', 'aac', '-b:a', bitrate],

--- a/js/metadata.js
+++ b/js/metadata.js
@@ -103,16 +103,14 @@ export async function addMetadataToAudio(audioBlob, track, _api, _quality, prefe
         }
 
         try {
-            if (track.album?.cover) {
-                const coverBlob = await coverFetch;
+            const coverBlob = await coverFetch;
 
-                if (coverBlob) {
-                    const coverBuffer = new Uint8Array(await coverBlob.arrayBuffer());
-                    data.cover = {
-                        data: coverBuffer,
-                        type: getMimeType(coverBuffer),
-                    };
-                }
+            if (coverBlob) {
+                const coverBuffer = new Uint8Array(await coverBlob.arrayBuffer());
+                data.cover = {
+                    data: coverBuffer,
+                    type: getMimeType(coverBuffer),
+                };
             }
         } catch (e) {
             console.warn('Error setting cover metadata.', track, e);

--- a/js/storage.js
+++ b/js/storage.js
@@ -4,9 +4,7 @@ import { SVG_RIGHT_ARROW } from './icons';
 
 export const apiSettings = {
     STORAGE_KEY: 'monochrome-api-instances-v9',
-    INSTANCES_URLS: [
-        'https://tidal-uptime.geeked.wtf',
-    ],
+    INSTANCES_URLS: ['https://tidal-uptime.geeked.wtf'],
     defaultInstances: { api: [], streaming: [], qobuz: [] },
     userInstances: null,
     instancesLoaded: false,
@@ -98,9 +96,7 @@ export const apiSettings = {
                         { url: 'https://hund.qqdl.site', version: '2.6' },
                         { url: 'https://wolf.qqdl.site', version: '2.6' },
                     ],
-                    qobuz: [
-                        { url: 'https://qobuz.kennyy.com.br', version: '1.0' },
-                    ],
+                    qobuz: [{ url: 'https://qobuz.kennyy.com.br', version: '1.0' }],
                 };
                 this.instancesLoaded = true;
                 this._loadPromise = null;
@@ -130,9 +126,7 @@ export const apiSettings = {
 
             // Ensure default Qobuz instance is always available
             if (groupedInstances.qobuz.length === 0) {
-                groupedInstances.qobuz = [
-                    { url: 'https://qobuz.kennyy.com.br', version: '1.0' },
-                ];
+                groupedInstances.qobuz = [{ url: 'https://qobuz.kennyy.com.br', version: '1.0' }];
             }
 
             this.defaultInstances = groupedInstances;

--- a/js/ui.js
+++ b/js/ui.js
@@ -6110,7 +6110,9 @@ export class UIRenderer {
 
                 container.innerHTML =
                     renderGroup(apiInstances, 'api') +
-                    (streamingInstances && streamingInstances.length > 0 ? renderGroup(streamingInstances, 'streaming') : '') +
+                    (streamingInstances && streamingInstances.length > 0
+                        ? renderGroup(streamingInstances, 'streaming')
+                        : '') +
                     renderGroup(qobuzInstances, 'qobuz');
 
                 const stats = this.api.getCacheStats();

--- a/styles.css
+++ b/styles.css
@@ -2163,7 +2163,6 @@ input[type='search']::-webkit-search-cancel-button {
     text-decoration: underline;
 }
 
-
 @media (max-width: 1100px) {
     #home-recommended-songs,
     #artist-detail-tracks,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
         "types": ["vite/client", "node", "@types/wicg-file-system-access"],
         "baseUrl": ".",
         "paths": {
-            "!/*": ["node_modules/*"],
+            "!/*": ["node_modules/*"]
         },
         "allowJs": true,
         "checkJs": false,
@@ -16,8 +16,8 @@
         "verbatimModuleSyntax": true,
         "ignoreDeprecations": "5.0",
         "skipLibCheck": true,
-        "noEmit": true,
+        "noEmit": true
     },
     "include": ["**/*.ts", "*.ts", "**/*.js", "*.js"],
-    "exclude": ["**/node_modules/*"],
+    "exclude": ["**/node_modules/*"]
 }


### PR DESCRIPTION
Some tracks returned by the TIDAL API have `album.cover: null` in their track-level album sub-object even when the album endpoint has a valid cover UUID. Multiple bugs caused this to silently drop cover art from downloaded files, including when albums are played via the card play button.

### Description

- **`js/metadata.js` — `addMetadataToAudio`**: The gate `if (track.album?.cover)` checked only one field, but `coverFetch` is populated by `prefetchMetadataObjects` via `getTrackCoverId()` which has fallbacks (`track.cover`, `track.album?.coverId`, etc.). Any cover fetched through a fallback was silently discarded. Replaced the gate with a direct null-check on the resolved blob.

- **`js/api.js` — `getAlbum`**: The album endpoint's per-track objects often have `album.cover: null` even when the parent album has a valid cover UUID. When tracks were queued from the album card, they would be missing cover data entirely. Now the parent album's cover is propagated to each track: `cover: t.album.cover || album.cover`.

- **`js/api.js` — `enrichTrack` (merge fix)**: The `EnrichedAlbum` merge `{ ...albumData.album, ...enrichedTrack.album }` allowed an explicit `null` in the track's `album.cover` to clobber the valid cover from the full album fetch. Fixed with an explicit cover preservation:
  ```js
  enrichedTrack.album = new EnrichedAlbum({
      ...albumData.album,
      ...enrichedTrack.album,
      cover: enrichedTrack.album?.cover || albumData.album?.cover,
  });
  ```

- **`js/api.js` — `enrichTrack` (condition fix)**: The album fetch in `enrichTrack` was only triggered when disc info was missing (`totalDiscs == null || numberOfTracksOnDisc == null`). If a track already had disc info populated (e.g. from the album queue) but lacked a cover, the album fetch was skipped and the cover was never recovered. The condition now also triggers when `!track.album?.cover`, ensuring the cached `getAlbum` result is always used to supply a cover when needed.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist

- [ ] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [ ] I have tested these changes locally, and they work as expected.
- [x] Is this Pull request Using AI/Is Vibecoded?

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced metadata enrichment for tracks—automatically fetches album data when cover or disc information is missing.

* **Bug Fixes**
  * Improved cover image retrieval logic for more reliable metadata handling.
  * Fixed HTML structure in navigation layout.

* **Style**
  * Added underline effect on library-source link hover.

* **Chores**
  * Code formatting refinements and JSON syntax cleanup across configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->