### PR TITLE
fix by preloading the theme before the page loads

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,6 +111,38 @@
                 href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600;700;800&family=Noto+Sans+SC:wght@400;500;600;700&family=Noto+Sans+TC:wght@400;500;600;700&family=Noto+Sans+HK:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;600;700&family=Noto+Sans+KR:wght@400;500;600;700&family=Noto+Sans+Hebrew:wght@400;500;600;700&family=Noto+Sans+Arabic:wght@400;500;600;700&family=Noto+Sans+Devanagari:wght@400;500;600;700&family=Noto+Sans+Bengali:wght@400;500;600;700&family=Noto+Sans+Thai:wght@400;500;600;700&family=Noto+Sans+Tamil:wght@400;500;600;700&family=Noto+Sans+Telugu:wght@400;500;600;700&family=Noto+Sans+Gujarati:wght@400;500;600;700&family=Noto+Sans+Kannada:wght@400;500;600;700&family=Noto+Sans+Malayalam:wght@400;500;600;700&family=Noto+Sans+Sinhala:wght@400;500;600;700&family=Noto+Sans+Khmer:wght@400;500;600;700&family=Noto+Sans+Lao:wght@400;500;600;700&family=Noto+Sans+Myanmar:wght@400;500;600;700&family=Noto+Sans+Georgian:wght@400;500;600;700&family=Noto+Sans+Armenian:wght@400;500;600;700&family=Noto+Sans+Ethiopic:wght@400;500;600;700&display=swap"
             />
         </noscript>
+        <script>
+            (() => {
+                try {
+                    const theme = localStorage.getItem('monochrome-theme');
+                    const css = localStorage.getItem('custom_theme_css');
+                    const palette = localStorage.getItem('monochrome-custom-theme');
+                    if (!theme) return;
+
+                    document.documentElement.setAttribute('data-theme', theme);
+
+                    if (theme === 'custom') {
+                        if (css) {
+                            let styleEl = document.getElementById('custom-theme-style');
+                            if (!styleEl) {
+                                styleEl = document.createElement('style');
+                                styleEl.id = 'custom-theme-style';
+                                document.head.appendChild(styleEl);
+                            }
+                            styleEl.textContent = css;
+                        } else if (palette) {
+                            const colors = JSON.parse(palette);
+                            const root = document.documentElement;
+                            for (const [key, value] of Object.entries(colors)) {
+                                root.style.setProperty(`--${key}`, value);
+                            }
+                        }
+                    }
+                } catch (e) {
+                    console.error('theme loading failed', e);
+                }
+            })();
+        </script>
         <link rel="stylesheet" href="/styles.css" />
     </head>
 


### PR DESCRIPTION
### Description
When the site is loading the theme flickers like loads the default theme and then switches to the theme selected

how i fixed it 
so the theme and all custom theme are stored in the localstorage
the js (in themeStore.js) runs after the page is loaded causing the flicker 
I just made sure that the theme is loaded before the html body is loaded by running a script in the head tag which give attributes and css 

I didnt change any metadata or any other logic , the same thing happens twice as theme is set once before page loading and again in themeStore, but ig it has place no need to change or modify or change it .

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Style/UI update
- [ ] Docs only

### Checklist

- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.
- [ ] Is this Pull request Using AI/Is Vibecoded?

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User theme preferences, including selected theme, custom CSS styling, and color palette configurations, are now automatically loaded and applied on page load. This ensures a seamless, consistent, and personalized user experience across browser sessions. Preferences persist without manual reconfiguration, backed by robust error handling mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->