### PR TITLE
Implement logarithmic volume

### DIFF
--- a/js/audio-context.js
+++ b/js/audio-context.js
@@ -804,8 +804,11 @@ class AudioContextManager {
     setVolume(value) {
         this.currentVolume = Math.max(0, Math.min(1, value));
         if (this.volumeNode && this.audioContext) {
+            const maximum = 1000;
             const now = this.audioContext.currentTime;
-            this.volumeNode.gain.setTargetAtTime(this.currentVolume, now, 0.01);
+
+            const logVolume = Math.pow(maximum, this.currentVolume - 1);
+            this.volumeNode.gain.setTargetAtTime(logVolume, now, 0.01);
             window.dispatchEvent(new CustomEvent('volume-change'));
         }
     }

--- a/js/audio-context.js
+++ b/js/audio-context.js
@@ -805,10 +805,12 @@ class AudioContextManager {
         this.currentVolume = Math.max(0, Math.min(1, value));
         if (this.volumeNode && this.audioContext) {
             const maximum = 1000;
+            const minimum = 1 / maximum;
             const now = this.audioContext.currentTime;
 
             const logVolume = Math.pow(maximum, this.currentVolume - 1);
-            this.volumeNode.gain.setTargetAtTime(logVolume, now, 0.01);
+            const normalized = (logVolume - minimum) / (1 - minimum);
+            this.volumeNode.gain.setTargetAtTime(normalized, now, 0.01);
             window.dispatchEvent(new CustomEvent('volume-change'));
         }
     }


### PR DESCRIPTION
### Description
Hello! I just began using Monochrome today, and I instantly fell in love.
But I immediately noticed that the volume was scaling unnaturally - that is, it would only lower at the bottom 5ths portion of the slider. This PR fixes that by adding logarithmic volume scaling.

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist

- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.
- [ ] Is this Pull request Using AI/Is Vibecoded?

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Volume control now uses logarithmic scaling for more natural, perceptual adjustments. This makes changes feel more consistent across the full range, preserves smooth transition behavior and responsiveness, and reduces abrupt jumps at low or high levels so volume adjustments are more predictable and comfortable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monochrome-music/monochrome/pull/671?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->