### PR TITLE
feat: enhance metadata handling for `TIDAL_DATA` in audio files downl…

### DIFF
--- a/js/metadata.js
+++ b/js/metadata.js
@@ -192,6 +192,15 @@ export async function readTrackMetadata(file, { filename = file?.name || 'Unknow
             metadata.isrc = data.isrc || metadata.isrc;
             metadata.copyright = data.copyright || metadata.copyright;
             metadata.explicit = !!data.explicit;
+
+            // Attempt to parse TIDAL_DATA if present
+            if (data.extra?.TIDAL_DATA) {
+                try {
+                    metadata.tidalData = JSON.parse(data.extra.TIDAL_DATA);
+                } catch {
+                    metadata.tidalData = data.extra.TIDAL_DATA;
+                }
+            }
         }
     } catch (e) {
         console.warn('Error reading metadata for', filename, e);

--- a/js/taglib.worker.ts
+++ b/js/taglib.worker.ts
@@ -279,6 +279,29 @@ export async function getMetadataFromAudio(message: _GetMetadataMessage): Promis
         }
     }
 
+    // Custom tags written by addMetadataToAudio
+    // I will only add TIDAL_DATA here for now
+    // since it contains all the other information 
+    // related to TIDAL, and I don't want to clutter
+    // the main metadata with too many custom fields
+    const extra: Record<string, string> = {};
+    const tidalTrackId = props.get('TIDAL_TRACK_ID')?.[0];
+    const tidalAlbumId = props.get('TIDAL_ALBUM_ID')?.[0];
+    const tidalTrackUrl = props.get('TIDAL_TRACK_URL')?.[0];
+    const tidalAlbumUrl = props.get('TIDAL_ALBUM_URL')?.[0];
+    const albumReleaseDate = props.get('ALBUM_RELEASE_DATE')?.[0];
+    const tidalDataRaw = props.get('TIDAL_DATA')?.[0];
+    if (tidalTrackId) extra.TIDAL_TRACK_ID = tidalTrackId;
+    if (tidalAlbumId) extra.TIDAL_ALBUM_ID = tidalAlbumId;
+    if (tidalTrackUrl) extra.TIDAL_TRACK_URL = tidalTrackUrl;
+    if (tidalAlbumUrl) extra.TIDAL_ALBUM_URL = tidalAlbumUrl;
+    if (albumReleaseDate) extra.ALBUM_RELEASE_DATE = albumReleaseDate;
+    if (tidalDataRaw) extra.TIDAL_DATA = tidalDataRaw;
+
+    if (Object.keys(extra).length > 0) {
+        data.extra = extra;
+    }
+
     return data;
 }
 


### PR DESCRIPTION
Loaded via Monochrome

### Description
`addMetadataToAudio` stores a full serialized copy of the track object inside `TIDAL_DATA`. This was previously not recovered when reading a tagged local file. Now Local files that were downloaded with Monochrome will be able to read the metadata.

### Type of Change

- [x] Bug fix
- [x] New feature

### Checklist

- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.
- [ ] Is this Pull request Using AI/Is Vibecoded?

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced metadata extraction to support TIDAL data from audio files, including track IDs, album IDs, URLs, and release date information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->