### PR TITLE
Fix cover image not working for some covers in fullscreen UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,7 +302,6 @@
                         <div class="fullscreen-media-column">
                             <div class="fullscreen-artwork-card" id="fullscreen-artwork-card">
                                 <img
-                                    crossorigin="anonymous"
                                     referrerpolicy="no-referrer"
                                     id="fullscreen-cover-image"
                                     src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"


### PR DESCRIPTION
### Description
Used to fix by right clicking and pressing "Load Image" but this is probably a better solution

### Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist

- [X] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [X] **I understand every line of code I am submitting.**
- [X] I have tested these changes locally, and they work as expected.
- [ ] Is this Pull request Using AI/Is Vibecoded?

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._

## before change:
<img width="1404" height="857" alt="image" src="https://github.com/user-attachments/assets/82c4609d-f231-4b3b-9017-5e87567f1fd9" />

## after change:
<img width="1405" height="856" alt="image" src="https://github.com/user-attachments/assets/44144be5-f45c-4b4a-af56-7f7ad4ed24ca" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fullscreen album artwork behavior by removing an unnecessary image loading setting that could interfere with display in some browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->