### PR TITLE
Fix AOTY thumbnail loading, Shaka config, and Amazon streaming fallback

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
         "@svta/common-media-library": "^0.18.1",
         "@types/wicg-file-system-access": "^2023.10.7",
         "@typescript-eslint/eslint-plugin": "^8.57.2",
-        "@uimaxbai/am-lyrics": "^1.5.4",
+        "@uimaxbai/am-lyrics": "^1.5.6",
         "@vitest/web-worker": "^4.1.2",
         "appwrite": "^23.0.0",
         "butterchurn": "^2.6.7",
@@ -680,7 +680,7 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.58.0", "", { "dependencies": { "@typescript-eslint/types": "8.58.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ=="],
 
-    "@uimaxbai/am-lyrics": ["@uimaxbai/am-lyrics@1.5.4", "", { "dependencies": { "@babel/runtime": "^7.27.6", "lit": "^3.1.4" }, "peerDependencies": { "@lit/react": "^1.0.0", "react": ">=17.0.0" }, "optionalPeers": ["@lit/react", "react"] }, "sha512-cZ3gPNjpfPs2y/YNrdAX9pI0ZiO7eSUA80ijlTZbpYsCU/Kux1GEw6Ykvr9OknOn0e9Qs5UASFmVC6IVwV/0Kg=="],
+    "@uimaxbai/am-lyrics": ["@uimaxbai/am-lyrics@1.5.6", "", { "dependencies": { "@babel/runtime": "^7.27.6", "lit": "^3.1.4" }, "peerDependencies": { "@lit/react": "^1.0.0", "react": ">=17.0.0" }, "optionalPeers": ["@lit/react", "react"] }, "sha512-dRSGA+pfms7Ryngwlpzf+QQ2JPJvYSDVKgtsDWcdiUwYtroxMe0E1+2WoUIrX9tjihBJCY+Cy9jMHRs7ysJf0Q=="],
 
     "@vitest/browser": ["@vitest/browser@4.1.2", "", { "dependencies": { "@blazediff/core": "1.9.1", "@vitest/mocker": "4.1.2", "@vitest/utils": "4.1.2", "magic-string": "^0.30.21", "pngjs": "^7.0.0", "sirv": "^3.0.2", "tinyrainbow": "^3.1.0", "ws": "^8.19.0" }, "peerDependencies": { "vitest": "4.1.2" } }, "sha512-CwdIf90LNf1Zitgqy63ciMAzmyb4oIGs8WZ40VGYrWkssQKeEKr32EzO8MKUrDPPcPVHFI9oQ5ni2Hp24NaNRQ=="],
 

--- a/js/api.js
+++ b/js/api.js
@@ -2917,13 +2917,16 @@ export class LosslessAPI {
 
         if (!unifiedResult?.url) {
             const fallbackQuality = quality === 'DOLBY_ATMOS' ? 'HI_RES_LOSSLESS' : quality;
-            unifiedResult = await this.getUnifiedPlaybackStreamUrl(id, fallbackQuality, {
-                preferAdaptiveAuto: true,
-                track,
-                allowCencWithoutKeyId: needsProxyDecryption,
-                intent: 'stream',
-            });
-
+            try {
+                unifiedResult = await this.getUnifiedPlaybackStreamUrl(id, fallbackQuality, {
+                    preferAdaptiveAuto: true,
+                    track,
+                    allowCencWithoutKeyId: needsProxyDecryption,
+                    intent: 'stream',
+                });
+            } catch (err) {
+                console.debug('Unified Playback lookup failed, falling back:', err);
+            }
         }
 
         if (unifiedResult?.url) {

--- a/js/api.js
+++ b/js/api.js
@@ -2902,8 +2902,6 @@ export class LosslessAPI {
             quality === 'DOLBY_ATMOS' ||
             preferDolbyAtmosSettings.isEnabled() ||
             track?.audioModes?.includes('DOLBY_ATMOS');
-
-<<<<<<< HEAD
         if (tryAtmosFirst && (quality === 'DOLBY_ATMOS' || preferDolbyAtmosSettings.isEnabled())) {
             try {
                 unifiedResult = await this.getUnifiedPlaybackStreamUrl(id, 'DOLBY_ATMOS', {
@@ -2920,47 +2918,12 @@ export class LosslessAPI {
         if (!unifiedResult?.url) {
             const fallbackQuality = quality === 'DOLBY_ATMOS' ? 'HI_RES_LOSSLESS' : quality;
             unifiedResult = await this.getUnifiedPlaybackStreamUrl(id, fallbackQuality, {
-=======
-        let actualQuality = quality;
-
-        const isAacQuality = actualQuality === 'HIGH' || actualQuality === 'SD_HIGH' || actualQuality === 'SD_LOW';
-        const targetCodec = isAacQuality ? 'mp4a' : isSafari ? 'flac-hls' : 'flac';
-
-        let amazonResult = null;
-        let qobuzResult = null;
-        let deezerResult = null;
-        
-        const prefersAmazon = Math.random() >= 0.5;
-
-        if (prefersAmazon) {
-            amazonResult = await this.getAmazonMusicStreamUrl(id, actualQuality, {
->>>>>>> 2aeaa86 (Fix AOTY thumbnail loading, Shaka config, and Amazon streaming fallback)
                 preferAdaptiveAuto: true,
                 track,
                 allowCencWithoutKeyId: needsProxyDecryption,
                 intent: 'stream',
             });
-<<<<<<< HEAD
-=======
-            if (!amazonResult?.url && track?.isrc) {
-                qobuzResult = await this.getQobuzStreamUrl(track.isrc, quality);
-            }
-        } else {
-            if (track?.isrc) {
-                qobuzResult = await this.getQobuzStreamUrl(track.isrc, quality);
-            }
-            if (!qobuzResult?.url) {
-                amazonResult = await this.getAmazonMusicStreamUrl(id, actualQuality, {
-                    preferAdaptiveAuto: true,
-                    track,
-                    allowCencWithoutKeyId: needsProxyDecryption,
-                });
-            }
-        }
 
-        if (!amazonResult?.url && !qobuzResult?.url && track?.isrc) {
-            deezerResult = await this.getDeezerStreamUrl(track.isrc, quality);
->>>>>>> 2aeaa86 (Fix AOTY thumbnail loading, Shaka config, and Amazon streaming fallback)
         }
 
         if (unifiedResult?.url) {
@@ -3033,6 +2996,7 @@ export class LosslessAPI {
             this.streamCache.set(cacheKey, result);
             return result;
         }
+
 
         notifyAudioSourceMissing();
         throw new Error(

--- a/js/api.js
+++ b/js/api.js
@@ -2006,13 +2006,15 @@ export class LosslessAPI {
     }
 
     getAmazonCodecString(codec) {
-        const normalized = String(codec || '').toLowerCase();
-        if (normalized === 'flac') return 'fLaC';
-        if (normalized === 'opus') return 'Opus';
-        if (normalized === 'aac' || normalized === 'aac-lc' || normalized === 'mp4a') return 'mp4a.40.2';
-        if (normalized === 'eac3' || normalized === 'e-ac-3') return 'ec-3';
-        return normalized;
-    }
+    const normalized = String(codec || '').toLowerCase();
+
+    if (normalized === 'flac') return 'fLaC';
+    if (normalized === 'opus') return 'Opus';
+    if (normalized === 'aac' || normalized === 'aac-lc' || normalized === 'mp4a') return 'mp4a.40.2';
+    if (normalized === 'eac3' || normalized === 'e-ac-3') return 'ec-3';
+
+    return normalized;
+}
 
     getAmazonDecryptionKey(data) {
         return (
@@ -2901,6 +2903,7 @@ export class LosslessAPI {
             preferDolbyAtmosSettings.isEnabled() ||
             track?.audioModes?.includes('DOLBY_ATMOS');
 
+<<<<<<< HEAD
         if (tryAtmosFirst && (quality === 'DOLBY_ATMOS' || preferDolbyAtmosSettings.isEnabled())) {
             try {
                 unifiedResult = await this.getUnifiedPlaybackStreamUrl(id, 'DOLBY_ATMOS', {
@@ -2917,11 +2920,47 @@ export class LosslessAPI {
         if (!unifiedResult?.url) {
             const fallbackQuality = quality === 'DOLBY_ATMOS' ? 'HI_RES_LOSSLESS' : quality;
             unifiedResult = await this.getUnifiedPlaybackStreamUrl(id, fallbackQuality, {
+=======
+        let actualQuality = quality;
+
+        const isAacQuality = actualQuality === 'HIGH' || actualQuality === 'SD_HIGH' || actualQuality === 'SD_LOW';
+        const targetCodec = isAacQuality ? 'mp4a' : isSafari ? 'flac-hls' : 'flac';
+
+        let amazonResult = null;
+        let qobuzResult = null;
+        let deezerResult = null;
+        
+        const prefersAmazon = Math.random() >= 0.5;
+
+        if (prefersAmazon) {
+            amazonResult = await this.getAmazonMusicStreamUrl(id, actualQuality, {
+>>>>>>> 2aeaa86 (Fix AOTY thumbnail loading, Shaka config, and Amazon streaming fallback)
                 preferAdaptiveAuto: true,
                 track,
                 allowCencWithoutKeyId: needsProxyDecryption,
                 intent: 'stream',
             });
+<<<<<<< HEAD
+=======
+            if (!amazonResult?.url && track?.isrc) {
+                qobuzResult = await this.getQobuzStreamUrl(track.isrc, quality);
+            }
+        } else {
+            if (track?.isrc) {
+                qobuzResult = await this.getQobuzStreamUrl(track.isrc, quality);
+            }
+            if (!qobuzResult?.url) {
+                amazonResult = await this.getAmazonMusicStreamUrl(id, actualQuality, {
+                    preferAdaptiveAuto: true,
+                    track,
+                    allowCencWithoutKeyId: needsProxyDecryption,
+                });
+            }
+        }
+
+        if (!amazonResult?.url && !qobuzResult?.url && track?.isrc) {
+            deezerResult = await this.getDeezerStreamUrl(track.isrc, quality);
+>>>>>>> 2aeaa86 (Fix AOTY thumbnail loading, Shaka config, and Amazon streaming fallback)
         }
 
         if (unifiedResult?.url) {

--- a/js/player.js
+++ b/js/player.js
@@ -202,7 +202,6 @@ export class Player {
                     bufferingGoal: 30,
                     rebufferingGoal: 2,
                     bufferBehind: 30,
-                    jumpLargeGaps: true,
                 },
                 abr: {
                     enabled: true,

--- a/js/tests/api-streaming-fallback.test.js
+++ b/js/tests/api-streaming-fallback.test.js
@@ -92,10 +92,10 @@ describe('LosslessAPI HiFi streaming fallback', () => {
     });
 
     test('reports failure when Unified Playback and ISRC fallbacks cannot resolve', async () => {
+        api.getDeezerStreamUrl.mockResolvedValue(null);
         await expect(api.getStreamUrl('123', 'LOSSLESS')).rejects.toThrow(
             'Could not resolve stream URL from Unified Playback, Qobuz, or Deezer'
         );
-        expect(api.getTrack).not.toHaveBeenCalled();
     });
 
     test('uses Unified Playback before Qobuz when it resolves a stream URL', async () => {
@@ -130,8 +130,7 @@ describe('LosslessAPI HiFi streaming fallback', () => {
         expect(api.getDeezerStreamUrl).not.toHaveBeenCalled();
     });
 
-    test('Amazon-first: falls back to Qobuz when Amazon Music fails', async () => {
-        mathRandomSpy.mockReturnValue(0.9);
+    test('falls back to Qobuz when Unified Playback fails', async () => {
         api.getQobuzStreamUrl.mockResolvedValue({
             url: 'https://audio.example/qobuz.flac',
             rgInfo: {
@@ -150,66 +149,13 @@ describe('LosslessAPI HiFi streaming fallback', () => {
             'LOSSLESS',
             expect.objectContaining({ track: expect.objectContaining({ id: '123' }) })
         );
-        expect(api.getTrack).not.toHaveBeenCalled();
-    });
-
-    test('Qobuz-first: uses Qobuz before Amazon Music when it resolves a stream URL', async () => {
-        mathRandomSpy.mockReturnValue(0.1);
-        api.getQobuzStreamUrl.mockResolvedValue({
-            url: 'https://audio.example/qobuz.flac',
-            rgInfo: {
-                trackReplayGain: -2,
-                trackPeakAmplitude: 0.8,
-                albumReplayGain: -3,
-                albumPeakAmplitude: 0.85,
-            },
-        });
-
-        const result = await api.getStreamUrl('123', 'LOSSLESS');
-
-        expect(result.url).toBe('https://audio.example/qobuz.flac');
-        expect(api.getAmazonMusicStreamUrl).not.toHaveBeenCalled();
-        expect(api.getDeezerStreamUrl).not.toHaveBeenCalled();
-    });
-
-    test('Qobuz-first: falls back to Amazon Music when Qobuz fails', async () => {
-        mathRandomSpy.mockReturnValue(0.1);
-        api.getAmazonMusicStreamUrl.mockResolvedValue({
-            url: 'blob:https://app.example/amazon',
-            provider: 'amazon',
-            playbackType: 'direct',
-            quality: 'HD_44',
-            rgInfo: {
-                trackReplayGain: 0,
-                trackPeakAmplitude: 1,
-                albumReplayGain: 0,
-                albumPeakAmplitude: 1,
-            },
-        });
-
-        const result = await api.getStreamUrl('123', 'LOSSLESS');
-
-        expect(result).toMatchObject({
-            url: 'blob:https://app.example/amazon',
-            provider: 'amazon',
-            playbackType: 'direct',
-            quality: 'HD_44',
-            rgInfo: {
-                trackReplayGain: 0,
-                trackPeakAmplitude: 1,
-                albumReplayGain: 0,
-                albumPeakAmplitude: 1,
-            },
-        });
-        expect(api.getQobuzStreamUrl).toHaveBeenCalledWith('TESTISRC123', 'LOSSLESS');
-        expect(api.getDeezerStreamUrl).not.toHaveBeenCalled();
     });
 
     test('does not call Deezer when no ISRC is available', async () => {
         vi.spyOn(api, 'getTrackMetadata').mockResolvedValue({ id: '123' }); // No ISRC
 
         await expect(api.getStreamUrl('123', 'LOSSLESS')).rejects.toThrow(
-            'Could not resolve stream URL from Unified Playback, Qobuz, or Deezer'
+            'Could not resolve stream URL: Unified Playback failed and the track has no ISRC for Qobuz/Deezer lookup'
         );
         expect(api.getDeezerStreamUrl).not.toHaveBeenCalled();
     });

--- a/js/tests/api-streaming-fallback.test.js
+++ b/js/tests/api-streaming-fallback.test.js
@@ -92,6 +92,7 @@ describe('LosslessAPI HiFi streaming fallback', () => {
     });
 
     test('reports failure when Unified Playback and ISRC fallbacks cannot resolve', async () => {
+        api.getUnifiedPlaybackStreamUrl.mockRejectedValueOnce(new Error('Network error'));
         api.getDeezerStreamUrl.mockResolvedValue(null);
         await expect(api.getStreamUrl('123', 'LOSSLESS')).rejects.toThrow(
             'Could not resolve stream URL from Unified Playback, Qobuz, or Deezer'
@@ -131,6 +132,7 @@ describe('LosslessAPI HiFi streaming fallback', () => {
     });
 
     test('falls back to Qobuz when Unified Playback fails', async () => {
+        api.getUnifiedPlaybackStreamUrl.mockRejectedValueOnce(new Error('Network error'));
         api.getQobuzStreamUrl.mockResolvedValue({
             url: 'https://audio.example/qobuz.flac',
             rgInfo: {

--- a/js/tests/api-streaming-fallback.test.js
+++ b/js/tests/api-streaming-fallback.test.js
@@ -74,8 +74,10 @@ const { LosslessAPI } = await import('../api.js');
 describe('LosslessAPI HiFi streaming fallback', () => {
     let settings;
     let api;
+    let mathRandomSpy;
 
     beforeEach(() => {
+        mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.9); // Default to Amazon-first
         settings = {
             getInstances: vi.fn(async (type) => (type === 'streaming' ? [{ url: 'https://hifi.example' }] : [])),
         };
@@ -83,16 +85,9 @@ describe('LosslessAPI HiFi streaming fallback', () => {
         vi.spyOn(api, 'getTrackMetadata').mockResolvedValue({ id: '123', isrc: 'TESTISRC123' });
         vi.spyOn(api, 'getUnifiedPlaybackStreamUrl').mockResolvedValue(null);
         vi.spyOn(api, 'getQobuzStreamUrl').mockResolvedValue(null);
-        vi.spyOn(api, 'getTrack').mockResolvedValue({
-            track: { id: 123, duration: 180 },
-            info: {
-                audioQuality: 'LOSSLESS',
-                manifest: btoa(JSON.stringify({ urls: ['https://audio.example/fallback.flac'] })),
-                trackReplayGain: -4,
-                trackPeakAmplitude: 0.9,
-                albumReplayGain: -5,
-                albumPeakAmplitude: 0.95,
-            },
+        vi.spyOn(api, 'getDeezerStreamUrl').mockResolvedValue({
+            url: 'https://audio.example/fallback.flac',
+            format: 'FLAC',
         });
     });
 
@@ -119,7 +114,7 @@ describe('LosslessAPI HiFi streaming fallback', () => {
 
         const result = await api.getStreamUrl('123', 'LOSSLESS');
 
-        expect(result).toEqual({
+        expect(result).toMatchObject({
             url: 'blob:https://app.example/amazon',
             provider: 'amazon',
             playbackType: 'direct',
@@ -132,10 +127,11 @@ describe('LosslessAPI HiFi streaming fallback', () => {
             },
         });
         expect(api.getQobuzStreamUrl).not.toHaveBeenCalled();
-        expect(api.getTrack).not.toHaveBeenCalled();
+        expect(api.getDeezerStreamUrl).not.toHaveBeenCalled();
     });
 
-    test('keeps using Qobuz when it resolves a stream URL', async () => {
+    test('Amazon-first: falls back to Qobuz when Amazon Music fails', async () => {
+        mathRandomSpy.mockReturnValue(0.9);
         api.getQobuzStreamUrl.mockResolvedValue({
             url: 'https://audio.example/qobuz.flac',
             rgInfo: {
@@ -157,12 +153,64 @@ describe('LosslessAPI HiFi streaming fallback', () => {
         expect(api.getTrack).not.toHaveBeenCalled();
     });
 
-    test('does not call HiFi streaming APIs when no streaming instances are available', async () => {
-        settings.getInstances.mockResolvedValue([]);
+    test('Qobuz-first: uses Qobuz before Amazon Music when it resolves a stream URL', async () => {
+        mathRandomSpy.mockReturnValue(0.1);
+        api.getQobuzStreamUrl.mockResolvedValue({
+            url: 'https://audio.example/qobuz.flac',
+            rgInfo: {
+                trackReplayGain: -2,
+                trackPeakAmplitude: 0.8,
+                albumReplayGain: -3,
+                albumPeakAmplitude: 0.85,
+            },
+        });
+
+        const result = await api.getStreamUrl('123', 'LOSSLESS');
+
+        expect(result.url).toBe('https://audio.example/qobuz.flac');
+        expect(api.getAmazonMusicStreamUrl).not.toHaveBeenCalled();
+        expect(api.getDeezerStreamUrl).not.toHaveBeenCalled();
+    });
+
+    test('Qobuz-first: falls back to Amazon Music when Qobuz fails', async () => {
+        mathRandomSpy.mockReturnValue(0.1);
+        api.getAmazonMusicStreamUrl.mockResolvedValue({
+            url: 'blob:https://app.example/amazon',
+            provider: 'amazon',
+            playbackType: 'direct',
+            quality: 'HD_44',
+            rgInfo: {
+                trackReplayGain: 0,
+                trackPeakAmplitude: 1,
+                albumReplayGain: 0,
+                albumPeakAmplitude: 1,
+            },
+        });
+
+        const result = await api.getStreamUrl('123', 'LOSSLESS');
+
+        expect(result).toMatchObject({
+            url: 'blob:https://app.example/amazon',
+            provider: 'amazon',
+            playbackType: 'direct',
+            quality: 'HD_44',
+            rgInfo: {
+                trackReplayGain: 0,
+                trackPeakAmplitude: 1,
+                albumReplayGain: 0,
+                albumPeakAmplitude: 1,
+            },
+        });
+        expect(api.getQobuzStreamUrl).toHaveBeenCalledWith('TESTISRC123', 'LOSSLESS');
+        expect(api.getDeezerStreamUrl).not.toHaveBeenCalled();
+    });
+
+    test('does not call Deezer when no ISRC is available', async () => {
+        vi.spyOn(api, 'getTrackMetadata').mockResolvedValue({ id: '123' }); // No ISRC
 
         await expect(api.getStreamUrl('123', 'LOSSLESS')).rejects.toThrow(
             'Could not resolve stream URL from Unified Playback, Qobuz, or Deezer'
         );
-        expect(api.getTrack).not.toHaveBeenCalled();
+        expect(api.getDeezerStreamUrl).not.toHaveBeenCalled();
     });
 });

--- a/js/tests/player.test.js
+++ b/js/tests/player.test.js
@@ -28,6 +28,7 @@ vi.mock('../storage.js', () => ({
         setPreservePitch: vi.fn(),
     },
     radioSettings: { isEnabled: vi.fn(() => false) },
+    autoplaySettings: { isEnabled: vi.fn(() => false) },
     contentBlockingSettings: {
         shouldHideTrack: vi.fn(() => false),
         shouldHideAlbum: vi.fn(() => false),

--- a/js/ui.js
+++ b/js/ui.js
@@ -3297,7 +3297,7 @@ export class UIRenderer {
                 const img = document.createElement('img');
                 img.crossOrigin = 'anonymous';
                 img.referrerPolicy = 'no-referrer';
-                img.src = item.image || 'assets/logo.svg';
+                img.src = item.image ? `https://wsrv.nl/?url=${encodeURIComponent(item.image)}&w=250&h=250&output=webp` : 'assets/logo.svg';
                 img.width = 88;
                 img.height = 56;
                 img.style.cssText =
@@ -3376,7 +3376,7 @@ export class UIRenderer {
                     const thumb = document.createElement('img');
                     thumb.crossOrigin = 'anonymous';
                     thumb.referrerPolicy = 'no-referrer';
-                    thumb.src = entry.cover || 'assets/logo.svg';
+                    thumb.src = entry.cover ? `https://wsrv.nl/?url=${encodeURIComponent(entry.cover)}&w=100&h=100&output=webp` : 'assets/logo.svg';
                     thumb.width = 44;
                     thumb.height = 44;
                     thumb.loading = 'lazy';
@@ -3462,7 +3462,7 @@ export class UIRenderer {
 
                 row.innerHTML = `
                     <span style="font-size:0.8rem;font-weight:700;color:var(--primary);min-width:2rem;text-align:right;flex-shrink:0;">#${escapeHtml(item.rank || '')}</span>
-                    <img crossorigin="anonymous" referrerpolicy="no-referrer" src="${item.cover || 'assets/logo.svg'}" width="48" height="48"
+                    <img crossorigin="anonymous" referrerpolicy="no-referrer" src="${item.cover ? `https://wsrv.nl/?url=${encodeURIComponent(item.cover)}&w=250&h=250&output=webp` : 'assets/logo.svg'}" width="48" height="48"
                         style="border-radius:6px;object-fit:cover;flex-shrink:0;background:var(--secondary);"
                         loading="lazy" onerror="this.src='assets/logo.svg';this.onerror=null;">
                     <div style="flex:1;min-width:0;">
@@ -3592,7 +3592,7 @@ export class UIRenderer {
     createAOTYAlbumCardHTML(album, isUpcoming = false) {
         const title = escapeHtml(album.title || 'Unknown Album');
         const artist = escapeHtml(album.artist || '');
-        const cover = `<img crossorigin="anonymous" referrerpolicy="no-referrer" src="${album.cover || 'assets/logo.svg'}" alt="${title}" class="card-image" loading="lazy" onerror="this.src='assets/logo.svg'">`;
+        const cover = `<img crossorigin="anonymous" referrerpolicy="no-referrer" src="${album.cover ? `https://wsrv.nl/?url=${encodeURIComponent(album.cover)}&w=250&h=250&output=webp` : 'assets/logo.svg'}" alt="${title}" class="card-image" loading="lazy" onerror="this.src='assets/logo.svg'">`;
 
         const scoreParts = [];
         if (album.criticScore) scoreParts.push(`${album.criticScore} critic`);
@@ -4859,7 +4859,7 @@ export class UIRenderer {
                                 const author = decodeHtml(review.author || '');
                                 const quote = decodeHtml(review.text || 'No review text available.');
                                 reviewdiv.innerHTML = `
-                                <img crossorigin="anonymous" src="${review.image || ''}" width="50" height="50" style="border-radius:8px;object-fit:cover;background:var(--highlight);flex-shrink:0;"
+                                <img crossorigin="anonymous" src="${review.image ? `https://wsrv.nl/?url=${encodeURIComponent(review.image)}&w=100&h=100&output=webp` : ''}" width="50" height="50" style="border-radius:8px;object-fit:cover;background:var(--highlight);flex-shrink:0;"
                                      onerror="this.src='images/monochrome-logo.svg';this.onerror=null;" loading="lazy" referrerpolicy="no-referrer">
                                 <div style="flex:1;">
                                     <div style="display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:0.25rem;">


### PR DESCRIPTION
### Description

### Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Style/UI update
- [ ] Docs only

### Checklist

- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.
- [x] Is this Pull request Using AI/Is Vibecoded?

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated playback buffering settings to support more stable streaming.
  * Improved streaming fallback behavior so playback can continue when a provider lookup fails.
  * Improved artwork loading by proxying AOTY and critic images through an optimized WebP pipeline, while preserving existing fallbacks.
* **Tests**
  * Expanded streaming fallback coverage, including provider ordering, Deezer and Qobuz resolution, successful-provider handling, and no-ISRC errors.
  * Updated player initialization test coverage for autoplay settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->