### PR TITLE
Fix queue shuffling, add next, and track transition loading state

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -523,6 +523,7 @@ export async function initializePlayerEvents(player, audioPlayer, scrobbler, ui)
 
         element.addEventListener('timeupdate', async () => {
             if (player.activeElement !== element) return;
+            if (player.isLoadingTrack) return;
 
             const { currentTime, duration } = element;
             if (duration) {

--- a/js/player.js
+++ b/js/player.js
@@ -1063,6 +1063,7 @@ export class Player {
         }
 
         this.setLoadingState(true);
+        this.resetProgressUI();
 
         const previousActiveElement = this.activeElement;
         const shouldPreserveGestureToken =
@@ -1147,10 +1148,10 @@ export class Player {
         }
 
         if (activeElement) {
+            activeElement.pause();
             // Let Shaka overwrite the activeElement's decoder pipeline gracefully if we're carrying it over.
             // It manages its own buffering teardown implicitly when `load()` is executed.
             if (!this.shakaInitialized) {
-                activeElement.pause();
                 activeElement.src = '';
                 activeElement.removeAttribute('src');
                 activeElement.load();
@@ -1589,6 +1590,17 @@ export class Player {
             const isPaused = this.activeElement?.paused ?? true;
             if (playPauseBtn) playPauseBtn.innerHTML = isPaused ? SVG_PLAY(20) : SVG_PAUSE(20);
         }
+    }
+
+    resetProgressUI() {
+        document.querySelectorAll('#progress-fill, #fs-progress-fill').forEach(el => el.style.width = '0%');
+        document.querySelectorAll('#current-time, #fs-current-time').forEach(el => el.textContent = '0:00');
+        document.querySelectorAll('#total-time, #fs-total-time').forEach(el => el.textContent = '0:00');
+        document.querySelectorAll('#progress-bar, #fs-progress-bar').forEach(el => {
+            el.style.webkitMaskImage = '';
+            el.style.maskImage = '';
+            el.classList.remove('has-waveform', 'waveform-loaded');
+        });
     }
 
     async playAtIndex(index) {
@@ -2043,6 +2055,7 @@ export class Player {
 
         if (this.shuffleActive) {
             this.originalQueueBeforeShuffle = [...this.queue];
+            this.originalQueueBeforeShuffle.forEach((t, i) => t._originalIndex = i);
             const currentTrack = this.queue[this.currentQueueIndex];
 
             const tracksToShuffle = [...this.queue];
@@ -2065,7 +2078,10 @@ export class Player {
         } else {
             const currentTrack = this.shuffledQueue[this.currentQueueIndex];
             this.queue = [...this.originalQueueBeforeShuffle];
-            this.currentQueueIndex = this.queue.findIndex((t) => t.id === currentTrack?.id);
+            this.currentQueueIndex = currentTrack?._originalIndex ?? this.queue.findIndex((t) => t.id === currentTrack?.id);
+            if (this.currentQueueIndex === -1) {
+                 this.currentQueueIndex = this.queue.findIndex((t) => t.id === currentTrack?.id);
+            }
         }
 
         this.preloadCache.clear();
@@ -2181,7 +2197,15 @@ export class Player {
         // If we are shuffling, we might want to also add it to the original queue for consistency,
         // though syncing that is tricky. The standard logic often just appends to the active queue view.
         if (this.shuffleActive) {
-            this.originalQueueBeforeShuffle.push(...tracks); // Sync original queue
+            const currentTrack = this.shuffledQueue[this.currentQueueIndex];
+            const originalIndex = currentTrack?._originalIndex ?? this.originalQueueBeforeShuffle.findIndex((t) => t.id === currentTrack?.id);
+            
+            if (originalIndex !== -1 && originalIndex !== undefined) {
+                this.originalQueueBeforeShuffle.splice(originalIndex + 1, 0, ...tracks);
+            } else {
+                this.originalQueueBeforeShuffle.push(...tracks); // Sync original queue
+            }
+            this.originalQueueBeforeShuffle.forEach((t, i) => t._originalIndex = i);
         }
 
         await this.saveQueueState();
@@ -2191,12 +2215,7 @@ export class Player {
     async removeFromQueue(index) {
         const currentQueue = this.shuffleActive ? this.shuffledQueue : this.queue;
 
-        // If removing current track
-        if (index === this.currentQueueIndex) {
-            // If playing, we might want to stop or just let it finish?
-            // For now, let's just remove it.
-            // If it's the last track, playback will stop naturally or we handle it?
-        }
+        const isRemovingCurrent = index === this.currentQueueIndex;
 
         if (index < this.currentQueueIndex) {
             this.currentQueueIndex--;
@@ -2206,9 +2225,27 @@ export class Player {
 
         if (this.shuffleActive) {
             // Also remove from original queue
-            const originalIndex = this.originalQueueBeforeShuffle.findIndex((t) => t.id === removedTrack.id); // Simple ID check
-            if (originalIndex !== -1) {
+            const originalIndex = removedTrack._originalIndex ?? this.originalQueueBeforeShuffle.findIndex((t) => t.id === removedTrack.id); // Simple ID check
+            if (originalIndex !== -1 && originalIndex !== undefined) {
                 this.originalQueueBeforeShuffle.splice(originalIndex, 1);
+            }
+            this.originalQueueBeforeShuffle.forEach((t, i) => t._originalIndex = i);
+        }
+
+        if (isRemovingCurrent) {
+            if (this.currentQueueIndex < currentQueue.length) {
+                await this.playTrackFromQueue(0, 0);
+            } else {
+                const el = this.activeElement;
+                if (el) {
+                    el.pause();
+                    el.src = '';
+                }
+                this.currentTrack = null;
+                this.currentQueueIndex = -1;
+                if (UIRenderer.instance) {
+                    UIRenderer.instance.setCurrentTrack(null);
+                }
             }
         }
 

--- a/js/player.js
+++ b/js/player.js
@@ -2239,6 +2239,8 @@ export class Player {
             if (this.currentQueueIndex < currentQueue.length) {
                 await this.playTrackFromQueue(0, 0);
             } else {
+                this.playbackSequence++;
+                this.setLoadingState(false);
                 const el = this.activeElement;
                 if (el) {
                     el.pause();

--- a/js/player.js
+++ b/js/player.js
@@ -2177,6 +2177,9 @@ export class Player {
         if (this.shuffleActive) {
             this.shuffledQueue.push(...tracks);
             this.originalQueueBeforeShuffle.push(...tracks);
+            this.originalQueueBeforeShuffle.forEach((track, index) => {
+                track._originalIndex = index;
+            });
         }
 
         if (!this.currentTrack || this.currentQueueIndex === -1) {

--- a/js/player.js
+++ b/js/player.js
@@ -1595,7 +1595,7 @@ export class Player {
     resetProgressUI() {
         document.querySelectorAll('#progress-fill, #fs-progress-fill').forEach(el => el.style.width = '0%');
         document.querySelectorAll('#current-time, #fs-current-time').forEach(el => el.textContent = '0:00');
-        document.querySelectorAll('#total-time, #fs-total-time').forEach(el => el.textContent = '0:00');
+        document.querySelectorAll('#total-duration, #fs-total-duration').forEach(el => el.textContent = '0:00');
         document.querySelectorAll('#progress-bar, #fs-progress-bar').forEach(el => {
             el.style.webkitMaskImage = '';
             el.style.maskImage = '';

--- a/js/ui.js
+++ b/js/ui.js
@@ -2391,7 +2391,7 @@ export class UIRenderer {
             const duration = activeEl.duration || 0;
             const current = activeEl.currentTime || 0;
 
-            if (duration > 0) {
+            if (duration > 0 && !this.player.isLoadingTrack) {
                 // Only update progress if not currently seeking (user is dragging)
                 if (!isFsSeeking) {
                     const percent = (current / duration) * 100;


### PR DESCRIPTION
### Description
This PR addresses several significant bugs relating to the queue's internal state management and track transition UX:

1. **Queue Desync on Current Track Removal**: Fixed a bug where removing the currently playing track from the queue caused the internal `currentQueueIndex` to drift, breaking playback order. The player will now gracefully detect this and automatically start playing the track that shifted into that position, or stop playback if it was the last track.
2. **Duplicate Tracks in Shuffle**: Fixed an issue where un-shuffling a queue containing duplicate songs would snap to the first instance of that song rather than the correct instance. The queue now accurately maps and restores using a `_originalIndex` property.
3. **"Play Next" while Shuffled**: Adding a track to play next while shuffle was active used to incorrectly push the track to the very bottom of the un-shuffled queue. It now accurately splices into the `originalQueueBeforeShuffle` directly after the un-shuffled position of the current track.
4. **Track Transition Overlap**: When clicking next/previous, the previous song's audio would continue playing while the new song's cover art and title were showing, causing a jarring overlap while fetching the stream URL. The active element is now unconditionally paused the moment a new track is queued.
5. **Progress Bar Reversion Fix**: Fixed a visual bug where the progress bar would briefly revert to the old song's timestamp while the new song was loading. The loading state now blocks stale `timeupdate` and `requestAnimationFrame` events from overriding the 0:00 reset state.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist

- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.
- [x] Is this Pull request Using AI/Is Vibecoded?

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented progress bars and playback time displays from updating while a track is loading.
  * Reset playback progress/time indicators when starting a new track.
  * Improved track handoff by more reliably pausing the active media element during switching.
  * Enhanced shuffle accuracy by preserving/restoring the correct queue position, keeping shuffle order consistent when adding/removing tracks, and handling removal of the currently playing item more robustly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->