### PR TITLE
Enhance separator item with data attributes 

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,7 +181,13 @@
                 <li data-action="track-info" data-type-filter="track,video">Track info</li>
                 <li data-action="open-original-url" data-type-filter="track,video">Open original URL</li>
                 <li data-action="download">Download</li>
-                <li class="separator"></li>
+                <li class="separator"
+                    data-type-filter="track,album,artist"
+                    data-action="horizantal-rule"
+                    >
+                     <!-- IDK why adding a `data-action` is necessary, but without it
+                      the `data-type-filter` gets ignored; So I've added it -->
+                </li>
                 <li
                     data-action="block-track"
                     data-type-filter="track"


### PR DESCRIPTION
Added data attributes to separator list item for filtering.

### Description

Fixed the Horizontal rule so it only shows up when any item below it is shown. For example when selecting playlists.

Before:<br /><img width="199" height="332" alt="Before" src="https://github.com/user-attachments/assets/74450c6b-e7e6-4432-b9a6-5f876dd75a34" />

After:<br /><img width="199" height="315" alt="After" src="https://github.com/user-attachments/assets/d04fcc1e-8a7f-441c-9e17-0b2e0c56834f" />


### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist

- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.
- [ ] Is this Pull request Using AI/Is Vibecoded?
    - Yeah, this is fully slop coded and will break the site

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the context-menu separator to display appropriately for tracks, albums, and artists.
  * Added clearer behavior metadata for the separator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->