### PR TITLE
add discord rpc bridge to desktop app

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
         "@svta/common-media-library": "^0.18.1",
         "@types/wicg-file-system-access": "^2023.10.7",
         "@typescript-eslint/eslint-plugin": "^8.57.2",
-        "@uimaxbai/am-lyrics": "^1.5.4",
+        "@uimaxbai/am-lyrics": "^1.5.6",
         "@vitest/web-worker": "^4.1.2",
         "appwrite": "^23.0.0",
         "butterchurn": "^2.6.7",
@@ -680,7 +680,7 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.58.0", "", { "dependencies": { "@typescript-eslint/types": "8.58.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ=="],
 
-    "@uimaxbai/am-lyrics": ["@uimaxbai/am-lyrics@1.5.4", "", { "dependencies": { "@babel/runtime": "^7.27.6", "lit": "^3.1.4" }, "peerDependencies": { "@lit/react": "^1.0.0", "react": ">=17.0.0" }, "optionalPeers": ["@lit/react", "react"] }, "sha512-cZ3gPNjpfPs2y/YNrdAX9pI0ZiO7eSUA80ijlTZbpYsCU/Kux1GEw6Ykvr9OknOn0e9Qs5UASFmVC6IVwV/0Kg=="],
+    "@uimaxbai/am-lyrics": ["@uimaxbai/am-lyrics@1.5.6", "", { "dependencies": { "@babel/runtime": "^7.27.6", "lit": "^3.1.4" }, "peerDependencies": { "@lit/react": "^1.0.0", "react": ">=17.0.0" }, "optionalPeers": ["@lit/react", "react"] }, "sha512-dRSGA+pfms7Ryngwlpzf+QQ2JPJvYSDVKgtsDWcdiUwYtroxMe0E1+2WoUIrX9tjihBJCY+Cy9jMHRs7ysJf0Q=="],
 
     "@vitest/browser": ["@vitest/browser@4.1.2", "", { "dependencies": { "@blazediff/core": "1.9.1", "@vitest/mocker": "4.1.2", "@vitest/utils": "4.1.2", "magic-string": "^0.30.21", "pngjs": "^7.0.0", "sirv": "^3.0.2", "tinyrainbow": "^3.1.0", "ws": "^8.19.0" }, "peerDependencies": { "vitest": "4.1.2" } }, "sha512-CwdIf90LNf1Zitgqy63ciMAzmyb4oIGs8WZ40VGYrWkssQKeEKr32EzO8MKUrDPPcPVHFI9oQ5ni2Hp24NaNRQ=="],
 

--- a/index.html
+++ b/index.html
@@ -6806,6 +6806,8 @@
                 </div>
             </footer>
         </div>
+        <script type="module" src="/js/desktop-rpc.js"></script>
+        <script type="module" src="/js/rpc-listener.js"></script>
         <script type="module" src="/js/app.js"></script>
     </body>
 </html>

--- a/js/desktop-rpc.js
+++ b/js/desktop-rpc.js
@@ -1,0 +1,38 @@
+window.updateDiscordRPC = async function (media) {
+    if (!media) return;
+
+    const audio = document.querySelector("audio");
+
+    if (!audio) {
+        console.log("[RPC] no audio element");
+        return;
+    }
+
+    const position = Math.floor(audio.currentTime || 0);
+    const duration = Math.floor(audio.duration || 0);
+
+    if (!duration || duration === Infinity) {
+        console.log("[RPC] waiting for duration");
+        return;
+    }
+
+    await window.__TAURI__.core.invoke(
+        "discord_update_song",
+        {
+            title: media.title || "Unknown Song",
+            artist: media.artist || "Unknown Artist",
+            artwork: media.artwork?.[0]?.src || "",
+            position: Math.floor(audio.currentTime || 0),
+            duration: Math.floor(audio.duration || 0),
+            playing: !audio.paused
+        }
+    );
+
+    console.log(
+        "[RPC] updated",
+        media.title,
+        position,
+        "/",
+        duration
+    );
+};

--- a/js/rpc-listener.js
+++ b/js/rpc-listener.js
@@ -1,0 +1,17 @@
+console.log("[RPC] listener loaded");
+
+setInterval(() => {
+
+    const media = navigator.mediaSession?.metadata;
+
+    if (!media) {
+        return;
+    }
+
+    console.log("[RPC] listener update:", media.title);
+
+    if (window.updateDiscordRPC) {
+        window.updateDiscordRPC(media);
+    }
+
+}, 1000);


### PR DESCRIPTION
### if using desktop app, send song data to tauri for discord rpc

### Discord RPC Bridge

- [ ] Bug fix
- [*] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist

- [ *] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [* ] **I understand every line of code I am submitting.**
- [* ] I have tested these changes locally, and they work as expected.
- [* ] Is this Pull request Using AI/Is Vibecoded?

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added desktop integration that updates Discord Rich Presence with the currently playing song.
  * Playback metadata is detected automatically and synchronized while media is playing.
  * Updates include song details and playback state when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->