### PR TITLE
style: add volume tooltips for better user feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -401,6 +401,7 @@
                                     </button>
                                     <div id="fs-volume-bar" class="fs-volume-bar">
                                         <div id="fs-volume-fill" class="fs-volume-fill"></div>
+                                        <span id="fs-volume-tooltip" class="volume-tooltip"></span>
                                     </div>
                                 </div>
                             </div>
@@ -6861,6 +6862,7 @@
                         <button id="volume-btn" title="Mute"></button>
                         <div id="volume-bar" class="volume-bar">
                             <div id="volume-fill" class="volume-fill"></div>
+                            <span id="volume-tooltip" class="volume-tooltip"></span>
                         </div>
                         <button id="sleep-timer-btn-desktop" title="Sleep Timer">
                             <use svg="!lucide/clock.svg" size="20" />

--- a/js/events.js
+++ b/js/events.js
@@ -377,6 +377,7 @@ const sleepTimerBtnDesktop = document.getElementById('sleep-timer-btn-desktop');
 const _volumeBar = document.getElementById('volume-bar');
 const volumeFill = document.getElementById('volume-fill');
 const volumeBtn = document.getElementById('volume-btn');
+const volumeTooltips = document.querySelectorAll('.volume-tooltip');
 
 const updateVolumeUI = () => {
     const activeEl = Player.instance.activeElement;
@@ -384,8 +385,12 @@ const updateVolumeUI = () => {
     const volume = Player.instance.userVolume;
     volumeBtn.innerHTML = muted || volume === 0 ? SVG_MUTE(20) : SVG_VOLUME(20);
     const effectiveVolume = muted ? 0 : volume * 100;
+    const roundedVolume = Math.round(effectiveVolume);
     volumeFill.style.setProperty('--volume-level', `${effectiveVolume}%`);
     volumeFill.style.width = `${effectiveVolume}%`;
+    volumeTooltips.forEach((tooltip) => {
+        tooltip.textContent = `${roundedVolume}%`;
+    });
 };
 
 function clearSelection() {

--- a/styles.css
+++ b/styles.css
@@ -4781,6 +4781,33 @@ input:checked + .slider::before {
     box-shadow: 0 2px 4px rgb(0, 0, 0, 0.3);
 }
 
+.volume-bar, .fs-volume-bar {
+    position: relative;
+}
+.volume-tooltip {
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 4px 8px;
+    background: rgba(20, 20, 20, 0.9);
+    color: #fff;
+    font-size: 12px;
+    line-height: 1;
+    border-radius: 4px;
+    white-space: nowrap;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
+    z-index: 10;
+}
+.volume-bar:hover #volume-tooltip,
+.fs-volume-bar:hover #fs-volume-tooltip {
+    opacity: 1;
+    visibility: visible;
+}
+
 @media (max-width: 768px) {
     .fullscreen-volume-container {
         gap: 0.75rem;


### PR DESCRIPTION
### Description
added a tool-tip for when you hover over the volume bar
### Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Style/UI update
- [ ] Docs only

### Checklist

- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.
- [ ] Is this Pull request Using AI/Is Vibecoded?

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added volume percentage tooltips to standard and fullscreen volume controls.
  * Tooltips display the current rounded volume level and appear when hovering over the volume bars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->