### PR TITLE
Added the option to delete a `user-playlist` to the `context menu`

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,7 +182,7 @@
                 <li data-action="track-info" data-type-filter="track,video">Track info</li>
                 <li data-action="open-original-url" data-type-filter="track,video">Open original URL</li>
                 <li data-action="download">Download</li>
-                <li class="separator" data-type-filter="track,album,artist" data-action="horizantal-rule">
+                <li class="separator" data-type-filter="track,album,artist,user-playlist" data-action="horizantal-rule">
                     <!-- IDK why adding a `data-action` is necessary, but without it
                       the `data-type-filter` gets ignored; So I've added it -->
                 </li>
@@ -209,6 +209,13 @@
                     data-label-unblock="Unblock artist"
                 >
                     Block artist
+                </li>
+                <li 
+                    data-action="delete-user-playlist"
+                    data-type-filter="user-playlist"
+                    class="danger"
+                >
+                    Delete Playlist
                 </li>
             </ul>
         </div>

--- a/js/events.js
+++ b/js/events.js
@@ -31,6 +31,7 @@ import { partyManager } from './listening-party.js';
 import { MusicAPI } from './music-api.js';
 import { LyricsManager } from './lyrics.js';
 import { Player } from './player.js';
+import { UIRenderer } from './ui.js';
 
 let currentTrackIdForWaveform = null;
 let copiedTracks = [];
@@ -2105,6 +2106,14 @@ export async function handleTrackAction(
         } else {
             contentBlockingSettings.blockArtist(artistObj);
             showNotification(`Blocked artist: ${artistName || 'Unknown Artist'}`);
+        }
+    } else if (action === 'delete-user-playlist') {
+        const contextMenu = document.getElementById('context-menu');
+        const playlistId = item.id || item.uuid;
+        if (confirm('Are you sure you want to delete this playlist?')) {
+        await db.deletePlaylist(playlistId);
+        await syncManager.syncUserPlaylist({ id: playlistId }, 'delete');
+        UIRenderer.instance.renderLibraryPage();
         }
     }
 }

--- a/js/events.js
+++ b/js/events.js
@@ -2113,7 +2113,12 @@ export async function handleTrackAction(
         if (confirm('Are you sure you want to delete this playlist?')) {
         await db.deletePlaylist(playlistId);
         await syncManager.syncUserPlaylist({ id: playlistId }, 'delete');
-        UIRenderer.instance.renderLibraryPage();
+        try {
+            await UIRenderer.instance.renderLibraryPage();
+        } catch (error) {
+            console.error('Failed to refresh library after playlist deletion:', error);
+            showNotification('Playlist deleted, but the library could not be refreshed.');
+        }
         }
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -4048,6 +4048,10 @@ input:checked + .slider::before {
     color: var(--foreground);
 }
 
+#context-menu li.danger:hover {
+    background-color: var(--color-danger-hover);
+}
+
 #context-menu li.separator,
 #eq-node-context-menu li.separator {
     height: 1px;


### PR DESCRIPTION
### Description
Completed [this](https://github.com/monochrome-music/monochrome/issues/774)
### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist

- [x] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [x] **I understand every line of code I am submitting.**
- [x] I have tested these changes locally, and they work as expected.
- [ ] Is this Pull request Using AI/Is Vibecoded?

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Delete Playlist” action for user-created playlists.
  * Added a confirmation step before deleting a playlist.
  * The library refreshes automatically after playlist deletion.
  * Displays an error message if the library cannot refresh after deletion.

* **Style**
  * Added visual danger styling for destructive context-menu actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->