### PR TITLE
Removed artist name splitting via RegEx

### DIFF
--- a/js/lastfm.js
+++ b/js/lastfm.js
@@ -85,14 +85,6 @@ export class LastFMScrobbler {
         }
 
         if (typeof artistName !== 'string') return 'Unknown Artist';
-
-        // Strip featured artists: split on &, feat., ft., featuring, with, etc.
-        // Only keep the part BEFORE these indicators
-        artistName = artistName
-            .split(/\s*[&]\s*|\s+feat\.?\s+|\s+ft\.?\s+|\s+featuring\s+|\s+with\s+|\s+x\s+/i)[0]
-            .trim();
-
-        return artistName || 'Unknown Artist';
     }
 
     async generateSignature(params) {


### PR DESCRIPTION
### Description
A [user](https://github.com/monochrome-music/monochrome/issues/740) complained that the artist name was only being sent as half a name. fixed that.

[Discussion link](https://discord.com/channels/1457628745589456910/1458041083266207835/1538289467285053461).
### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist

- [ ] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [ ] **I understand every line of code I am submitting.**
- [ ] I have tested these changes locally, and they work as expected.
- [ ] Is this Pull request Using AI/Is Vibecoded?

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artist recognition for scrobbling by preserving featured-artist information in artist names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->