### PR TITLE
Fixed a broken URL generator for `header-account-img`

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2958,7 +2958,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (user) {
                 const data = await syncManager.getUserData();
                 if (data && data.profile && data.profile.avatar_url) {
-                    headerAccountImg.src = data.profile.avatar_url + '&s=100';
+                    headerAccountImg.src = data.profile.avatar_url + '?s=100';
                     headerAccountImg.style.display = 'block';
                     headerAccountIcon.style.display = 'none';
                     return;


### PR DESCRIPTION
### Description
Fixed the possible reason for [this](https://github.com/monochrome-music/monochrome/issues/734) issue.

It was the URL generator using `&s=100` instead of `?s=100` as the suffix to get a smaller sized image.
### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Style/UI update
- [ ] Docs only

### Checklist

- [ ] **I have read the [Contributing Guidelines](https://github.com/monochrome-music/monochrome/blob/main/CONTRIBUTING.md).**
- [ ] **I understand every line of code I am submitting.**
- [ ] I have tested these changes locally, and they work as expected.
- [ ] Is this Pull request Using AI/Is Vibecoded?

---

_By submitting this PR, I agree to follow the guidelines. I understand that the final decision to merge rests with the maintainers and that not all contributions can be accepted._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed account avatar images not loading correctly when the profile image URL has no existing query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->