### PR TITLE
Add Monochrome CLI for Termux and Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,12 @@ package-lock.json
 Caddyfile
 dev-dist
 load-balancer
+
+# Python (cli/)
+__pycache__/
+*.py[cod]
+*.egg-info/
+build/
+.pytest_cache/
+venv/
+.venv/

--- a/cli/README.md
+++ b/cli/README.md
@@ -142,13 +142,35 @@ está en el tamaño y la compatibilidad, no en la fidelidad.
 El archivo de configuración vive en `~/.config/monochrome-cli/config.json` y solo
 se escribe cuando cambias algo (arrancar `mono` no lo toca).
 
-Las credenciales de la API de Tidal no se guardan ahí. Si necesitas usar las
-tuyas, defínelas por entorno:
+### Credenciales de Tidal
+
+Las credenciales **no se guardan** en tu configuración. Se pueden sobreescribir
+por entorno:
 
 ```bash
 export MONOCHROME_TIDAL_CLIENT_ID="tu_id"
 export MONOCHROME_TIDAL_CLIENT_SECRET="tu_secreto"
 ```
+
+**Importante antes de intentar conseguir las tuyas:** existen dos APIs de Tidal
+distintas y no son intercambiables.
+
+| | API interna (la que usa este proyecto) | API oficial |
+| :--- | :--- | :--- |
+| Base | `api.tidal.com/v1` | `openapi.tidal.com/v2` |
+| Credenciales | Client ID interno de las apps de Tidal | [developer.tidal.com](https://developer.tidal.com) → crear una App |
+| ¿Se pueden pedir? | No; no hay proceso público para obtenerlas | Sí, registrándote |
+| Formato de respuesta | JSON propio | JSON:API |
+
+Las credenciales del portal oficial **no funcionan** con los endpoints `v1` que
+usa `core/search.py` (devuelven `400`), así que registrarte en el portal no basta
+para sustituir el valor por defecto: haría falta portar `search.py` a
+`openapi.tidal.com/v2`, que tiene rutas y formato de respuesta diferentes.
+
+Ten en cuenta que Tidal considera que `api.tidal.com` no está destinada a uso
+externo. Si buscas una fuente de metadatos sin credenciales, **Deezer**
+(`api.deezer.com`) ya está integrada como respaldo y su API de búsqueda es
+pública y no requiere ningún token.
 
 ---
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,171 @@
+# 🎵 Monochrome CLI (Terminal & Termux)
+
+Versión CLI y TUI (Text User Interface) inspirada en **Monochrome**, diseñada específicamente para terminales **Linux**, **macOS** y **Termux en Android**.
+
+Permite buscar canciones, álbumes y artistas con metadatos de alta fidelidad, descargar en varios formatos de salida (FLAC, MP3, M4A/AAC, OPUS), elegir si incluir o no letras sincronizadas (`.lrc`), incrustar carátulas en HD (1280x1280) y configurar preferencias fijas por defecto.
+
+## ⚙️ Cómo funciona (importante)
+
+Monochrome CLI combina dos fuentes distintas:
+
+- **Metadatos y carátulas**: catálogo de **Tidal** (con Deezer como respaldo). De ahí salen el título, artista, álbum, año, ISRC, número de pista y la portada en HD.
+- **Audio**: se localiza en **YouTube** mediante `yt-dlp`, eligiendo el resultado cuya duración coincide con la del catálogo. Se intenta primero el stream de solo audio (**~130 kbps** Opus/AAC) y, si YouTube lo bloquea, se cae automáticamente al stream progresivo (**~48-96 kbps**).
+
+Esto significa que **ninguna opción de salida produce audio sin pérdida real**: el formato solo decide cómo se guarda ese stream. `FLAC` evita una recompresión adicional pero multiplica el tamaño sin ganar calidad, y `opus` es el que menos degrada porque suele coincidir con el códec de origen.
+
+> Si ves calidades bajas de forma sistemática, es porque YouTube exige un *PO token* para los streams de solo audio en tu conexión. Mantén `yt-dlp` actualizado (`pip install -U yt-dlp`); es lo que más influye en qué formatos siguen accesibles.
+
+---
+
+## 🚀 Instalación en Termux (Android)
+
+### Método 1: Instalador Automático de 1 Comando
+En Termux, ejecuta:
+```bash
+bash install_termux.sh
+```
+
+### Método 2: Instalación Manual
+```bash
+# 1. Instalar paquetes base
+pkg update -y
+pkg install -y python ffmpeg git
+
+# 2. Habilitar permisos de almacenamiento en Android
+termux-setup-storage
+
+# 3. Instalar dependencias de Python
+pip install yt-dlp mutagen rich requests
+
+# 4. Instalar Monochrome CLI
+pip install -e ./cli
+```
+
+---
+
+## 💻 Instalación en Linux / macOS
+
+```bash
+# Dependencias del sistema (FFmpeg)
+sudo apt install ffmpeg python3-pip   # Debian / Ubuntu
+sudo pacman -S ffmpeg python-pip     # Arch Linux
+brew install ffmpeg python           # macOS
+
+# Instalar dependencias
+pip install yt-dlp mutagen rich requests
+
+# Instalar comando global `mono`
+pip install -e ./cli
+```
+
+---
+
+## 🎮 Guía de Uso
+
+### 1. Modo Interactivo TUI (Recomendado)
+Simplemente ejecuta:
+```bash
+mono
+```
+- Escribe el nombre de cualquier canción, álbum o artista.
+- Selecciona el número `#` de la canción que quieres descargar (o escribe `all` o un rango como `1-5`).
+- Al seleccionar una canción, puedes **presionar Enter** para descargar con tus opciones por defecto, o escribir **`c`** para elegir al momento el formato y si quieres incluir letras o no.
+- Escribe **`fmt`** para cambiar el formato de audio activo.
+- Escribe **`config`** para abrir el menú completo de opciones predeterminadas.
+
+---
+
+### 2. Modo Comando Directo (CLI)
+
+```bash
+# Descargar eligiendo formato en el momento
+mono "daft punk get lucky" -d -f flac
+mono "the weeknd starboy" -d -f mp3_320
+mono "dua lipa levitating" -d -f m4a
+
+# Descargar con o sin letras sincronizadas
+mono "queen bohemian rhapsody" -d --no-lyrics   # Sin archivo .lrc
+mono "queen bohemian rhapsody" -d --lyrics      # Con archivo .lrc
+
+# Descargar un álbum completo
+mono "tainy data" -a -f mp3_320
+
+# Forzar re-descarga si ya existe
+mono "daft punk get lucky" -d -w
+```
+
+---
+
+### ⚙️ Establecer Opciones Predeterminadas Fijas
+
+Puedes guardar tus preferencias permanentes con comandos rápidos o en el menú `config`:
+
+```bash
+# Establecer formato preferido para siempre (flac, mp3_320, mp3_256, m4a, opus)
+mono --set-default-format flac
+mono --set-default-format mp3_320
+
+# Establecer si siempre descargar letras (.lrc) por defecto
+mono --set-default-lyrics true
+mono --set-default-lyrics false
+
+# Establecer carpeta de descargas predeterminada permanente
+mono --set-default-output /sdcard/Music/Monochrome
+
+# Establecer el país del catálogo (afecta a qué ediciones y lanzamientos aparecen)
+mono --set-default-country ES
+
+# Abrir el menú interactivo de configuración
+mono --config
+```
+
+---
+
+## 🎛️ Formatos y Calidades Soportadas
+
+Todos parten del mismo stream de origen (~130-160 kbps), así que la diferencia
+está en el tamaño y la compatibilidad, no en la fidelidad.
+
+| Formato | Código | Contenedor | Cuándo usarlo |
+| :--- | :--- | :--- | :--- |
+| **OPUS** | `opus` | 160 kbps | **Recomendado**: mismo códec que la fuente, sin recodificar |
+| **MP3 320k** | `mp3_320` | 320 kbps CBR | Máxima compatibilidad con cualquier reproductor o coche |
+| **MP3 256k** | `mp3_256` | 256 kbps | Equilibrio entre tamaño y compatibilidad |
+| **M4A** | `m4a` | 256 kbps AAC | Ecosistema Apple |
+| **FLAC** | `flac` | Sin recompresión | Evita una recodificación extra; ocupa 4-5x más sin ganar calidad |
+| **MP3 128k** | `mp3_128` | 128 kbps | Ahorro máximo de espacio |
+
+---
+
+## 🔧 Configuración avanzada
+
+El archivo de configuración vive en `~/.config/monochrome-cli/config.json` y solo
+se escribe cuando cambias algo (arrancar `mono` no lo toca).
+
+Las credenciales de la API de Tidal no se guardan ahí. Si necesitas usar las
+tuyas, defínelas por entorno:
+
+```bash
+export MONOCHROME_TIDAL_CLIENT_ID="tu_id"
+export MONOCHROME_TIDAL_CLIENT_SECRET="tu_secreto"
+```
+
+---
+
+## 🧪 Tests
+
+```bash
+# Solo pruebas unitarias (sin red, menos de un segundo)
+python3 tests/test_units.py
+pytest tests/
+
+# Incluir las pruebas en vivo, que descargan audio real
+MONOCHROME_LIVE_TESTS=1 pytest tests/
+```
+
+---
+
+## 🛡️ Sistema Antiduplicados
+
+- Si una canción ya existe en disco, el sistema la detecta en **0.1 segundos** y la omite automáticamente para no gastar ancho de banda ni duplicar archivos.
+- Para forzar la re-descarga (por ejemplo al cambiar de calidad), añade la bandera `-w` o `--force`.

--- a/cli/monochrome_cli/__init__.py
+++ b/cli/monochrome_cli/__init__.py
@@ -1,0 +1,6 @@
+"""
+Monochrome CLI - Open-source, high-quality music search and downloader for Termux and Linux.
+"""
+
+__version__ = "1.0.0"
+__author__ = "Monochrome Music Community"

--- a/cli/monochrome_cli/config.py
+++ b/cli/monochrome_cli/config.py
@@ -1,0 +1,173 @@
+"""
+Configuration management for Monochrome CLI.
+"""
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+from monochrome_cli.types import AudioFormat
+from monochrome_cli.utils.platform import get_config_dir, get_default_music_dir
+
+# Credenciales públicas de la API de Tidal. Viven aquí y no en DEFAULT_CONFIG para
+# no acabar copiadas en el config.json de cada usuario; se pueden sobreescribir
+# con las variables de entorno MONOCHROME_TIDAL_CLIENT_ID / _SECRET o añadiendo
+# las claves a mano en el archivo de configuración.
+DEFAULT_TIDAL_CLIENT_ID = "txNoH4kkV41MfH25"
+DEFAULT_TIDAL_CLIENT_SECRET = "dQjy0MinCEvxi1O4UmxvxWnDjt4cgHBPw8ll6nYBk98="
+
+# Claves que versiones anteriores escribían en el config.json del usuario.
+LEGACY_KEYS = {
+    "tidal_client_id": DEFAULT_TIDAL_CLIENT_ID,
+    "tidal_client_secret": DEFAULT_TIDAL_CLIENT_SECRET,
+}
+
+
+class Config:
+    # Solo valores estáticos: nada que toque el disco al importar el módulo.
+    DEFAULT_CONFIG: Dict[str, Any] = {
+        "default_format": AudioFormat.MP3_320.value,
+        "embed_cover": True,
+        "cover_resolution": 1280,
+        "embed_lyrics": True,
+        "save_lrc_file": True,
+        "folder_template": "{album_artist}/{album}/{track_number:02d} - {title}",
+        "search_limit": 10,
+        "country_code": "US",
+    }
+
+    def __init__(self, config_path: Optional[Path] = None):
+        self.config_path = config_path or (get_config_dir() / "config.json")
+        self._data = dict(self.DEFAULT_CONFIG)
+        self.load()
+
+    def load(self) -> None:
+        if not self.config_path.exists():
+            # Sin archivo se usan los valores por defecto; se escribirá en el
+            # primer cambio real, no por arrancar la aplicación.
+            return
+        try:
+            with open(self.config_path, "r", encoding="utf-8") as f:
+                loaded = json.load(f)
+        except Exception as e:
+            print(f"[Aviso] No se pudo leer la configuración existente: {e}")
+            return
+
+        if not isinstance(loaded, dict):
+            print("[Aviso] La configuración existente no es válida; se ignoró.")
+            return
+
+        # Limpia las credenciales que se escribían por defecto, conservando las
+        # que el usuario haya cambiado a propósito.
+        removed_legacy = False
+        for key, default_value in LEGACY_KEYS.items():
+            if loaded.get(key) == default_value:
+                loaded.pop(key)
+                removed_legacy = True
+
+        self._data.update(loaded)
+        if removed_legacy:
+            self.save()
+
+    def save(self) -> None:
+        try:
+            self.config_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self.config_path, "w", encoding="utf-8") as f:
+                json.dump(self._data, f, indent=4, ensure_ascii=False)
+        except Exception as e:
+            print(f"[Error] No se pudo guardar la configuración: {e}")
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._data.get(key, default)
+
+    def set(self, key: str, value: Any) -> None:
+        self._data[key] = value
+        self.save()
+
+    def update(self, values: Dict[str, Any]) -> None:
+        """Aplica varios cambios con una sola escritura en disco."""
+        self._data.update(values)
+        self.save()
+
+    def reset_to_defaults(self) -> None:
+        self._data = dict(self.DEFAULT_CONFIG)
+        self.save()
+
+    @property
+    def download_directory(self) -> Path:
+        """
+        Carpeta de descargas. Es una consulta, no crea nada en disco: el
+        directorio se crea al guardar la primera pista.
+        """
+        stored = self.get("download_directory")
+        if stored:
+            return Path(stored).expanduser()
+        return get_default_music_dir()
+
+    @download_directory.setter
+    def download_directory(self, val: str) -> None:
+        self.set("download_directory", str(Path(val).expanduser()))
+
+    @property
+    def default_format(self) -> AudioFormat:
+        val = self.get("default_format", AudioFormat.MP3_320.value)
+        return AudioFormat.from_string(val)
+
+    @default_format.setter
+    def default_format(self, fmt: AudioFormat) -> None:
+        self.set("default_format", fmt.value)
+
+    @property
+    def embed_cover(self) -> bool:
+        return bool(self.get("embed_cover", True))
+
+    @property
+    def cover_resolution(self) -> int:
+        try:
+            return int(self.get("cover_resolution", 1280))
+        except (TypeError, ValueError):
+            return 1280
+
+    @property
+    def embed_lyrics(self) -> bool:
+        return bool(self.get("embed_lyrics", True))
+
+    @property
+    def save_lrc_file(self) -> bool:
+        return bool(self.get("save_lrc_file", True))
+
+    @property
+    def folder_template(self) -> str:
+        return str(self.get("folder_template", self.DEFAULT_CONFIG["folder_template"]))
+
+    @property
+    def search_limit(self) -> int:
+        try:
+            return int(self.get("search_limit", 10))
+        except (TypeError, ValueError):
+            return 10
+
+    @property
+    def country_code(self) -> str:
+        """Región del catálogo de Tidal; cambia qué lanzamientos son visibles."""
+        code = str(self.get("country_code", "US") or "US").strip().upper()
+        return code if len(code) == 2 and code.isalpha() else "US"
+
+    @property
+    def tidal_client_id(self) -> str:
+        return (
+            os.environ.get("MONOCHROME_TIDAL_CLIENT_ID")
+            or self.get("tidal_client_id")
+            or DEFAULT_TIDAL_CLIENT_ID
+        )
+
+    @property
+    def tidal_client_secret(self) -> str:
+        return (
+            os.environ.get("MONOCHROME_TIDAL_CLIENT_SECRET")
+            or self.get("tidal_client_secret")
+            or DEFAULT_TIDAL_CLIENT_SECRET
+        )
+
+
+# Global singleton instance
+config = Config()

--- a/cli/monochrome_cli/config.py
+++ b/cli/monochrome_cli/config.py
@@ -8,10 +8,16 @@ from typing import Any, Dict, Optional
 from monochrome_cli.types import AudioFormat
 from monochrome_cli.utils.platform import get_config_dir, get_default_music_dir
 
-# Credenciales públicas de la API de Tidal. Viven aquí y no en DEFAULT_CONFIG para
-# no acabar copiadas en el config.json de cada usuario; se pueden sobreescribir
-# con las variables de entorno MONOCHROME_TIDAL_CLIENT_ID / _SECRET o añadiendo
-# las claves a mano en el archivo de configuración.
+# Credenciales de la API interna de Tidal (api.tidal.com/v1). Son un client id
+# filtrado de las aplicaciones oficiales, no algo que se pueda solicitar: el
+# portal developer.tidal.com emite credenciales para otra API distinta
+# (openapi.tidal.com/v2), que estos endpoints rechazan con un 400. Ver el
+# apartado "Credenciales de Tidal" del README.
+#
+# Viven aquí y no en DEFAULT_CONFIG para no acabar copiadas en el config.json de
+# cada usuario; se pueden sobreescribir con las variables de entorno
+# MONOCHROME_TIDAL_CLIENT_ID / _SECRET o añadiendo las claves a mano al archivo
+# de configuración.
 DEFAULT_TIDAL_CLIENT_ID = "txNoH4kkV41MfH25"
 DEFAULT_TIDAL_CLIENT_SECRET = "dQjy0MinCEvxi1O4UmxvxWnDjt4cgHBPw8ll6nYBk98="
 

--- a/cli/monochrome_cli/core/__init__.py
+++ b/cli/monochrome_cli/core/__init__.py
@@ -1,0 +1,1 @@
+"""Núcleo: búsqueda, descarga, letras y etiquetado."""

--- a/cli/monochrome_cli/core/downloader.py
+++ b/cli/monochrome_cli/core/downloader.py
@@ -1,0 +1,333 @@
+"""
+Audio stream downloader and post-processor using yt-dlp, FFmpeg, and Mutagen.
+"""
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Tuple
+
+import yt_dlp
+
+from monochrome_cli.config import config
+from monochrome_cli.core.lyrics import LyricsManager
+from monochrome_cli.core.tagger import MetadataTagger
+from monochrome_cli.types import AudioFormat, TrackMetadata
+from monochrome_cli.utils.template import format_track_path
+
+# Extensiones de audio que FFmpeg puede haber generado en el directorio temporal.
+KNOWN_AUDIO_EXTENSIONS = ("flac", "mp3", "m4a", "opus", "ogg", "aac", "wav", "webm")
+
+
+class _SilentLogger:
+    """
+    Silencia la salida de yt-dlp. Que un perfil de descarga falle es parte del
+    flujo normal, así que el error se propaga como excepción en vez de ensuciar
+    la interfaz; el mensaje llega al usuario por el progress_callback.
+    """
+
+    def debug(self, msg):
+        pass
+
+    def info(self, msg):
+        pass
+
+    def warning(self, msg):
+        pass
+
+    def error(self, msg):
+        pass
+
+
+class Downloader:
+    # Cuántos resultados de YouTube se examinan para encontrar la versión correcta.
+    SEARCH_CANDIDATES = 8
+    # Margen aceptable entre la duración del catálogo y la del vídeo, en segundos.
+    DURATION_TOLERANCE = 4
+
+    # Perfiles de extracción, en orden de preferencia.
+    #
+    # El primero usa los clientes por defecto de yt-dlp, que ofrecen streams de
+    # solo audio a ~130 kbps. Cuando YouTube los bloquea (403 por falta de PO
+    # token), el segundo fuerza los clientes web/android: solo entregan el
+    # formato progresivo 18, de menor calidad, pero descarga sin token.
+    DOWNLOAD_PROFILES = (
+        ("audio de máxima calidad disponible", None),
+        (
+            "stream progresivo de respaldo (menor calidad)",
+            {"youtube": {"player_client": ["web", "android"]}},
+        ),
+    )
+
+    @staticmethod
+    def _create_yt_dlp_params(
+        temp_dir: Path,
+        audio_format: AudioFormat,
+        progress_hook: Optional[Callable[[dict], None]] = None,
+        extractor_args: Optional[Dict] = None
+    ) -> dict:
+        ffmpeg_info = audio_format.ffmpeg_args
+        ext = ffmpeg_info["ext"]
+        bitrate = ffmpeg_info.get("bitrate")
+
+        postprocessors = [{
+            "key": "FFmpegExtractAudio",
+            "preferredcodec": ext,
+        }]
+        if bitrate:
+            postprocessors[0]["preferredquality"] = bitrate.rstrip("k")
+
+        ydl_opts = {
+            "format": "bestaudio/best",
+            "outtmpl": str(temp_dir / "%(id)s.%(ext)s"),
+            "quiet": True,
+            "no_warnings": True,
+            "noprogress": True,
+            "logger": _SilentLogger(),
+            "postprocessors": postprocessors,
+            "prefer_ffmpeg": True,
+        }
+
+        if extractor_args:
+            ydl_opts["extractor_args"] = extractor_args
+
+        if progress_hook:
+            ydl_opts["progress_hooks"] = [progress_hook]
+
+        return ydl_opts
+
+    @classmethod
+    def _search_candidates(cls, query: str, limit: int) -> List[dict]:
+        """
+        Búsqueda plana (sin descargar) que devuelve título, duración y URL de cada
+        resultado. Es rápida porque no resuelve los streams de cada vídeo.
+        """
+        opts = {
+            "quiet": True,
+            "no_warnings": True,
+            "skip_download": True,
+            "extract_flat": "in_playlist",
+            "logger": _SilentLogger(),
+        }
+        try:
+            with yt_dlp.YoutubeDL(opts) as ydl:
+                info = ydl.extract_info(f"ytsearch{limit}:{query}", download=False)
+        except Exception:
+            return []
+        entries = (info or {}).get("entries") or []
+        return [e for e in entries if e and (e.get("url") or e.get("webpage_url"))]
+
+    @classmethod
+    def _pick_best_candidate(
+        cls,
+        entries: List[dict],
+        target_duration: int
+    ) -> Tuple[Optional[dict], Optional[int], bool]:
+        """
+        Elige el resultado cuya duración se acerca más a la del catálogo.
+
+        Devuelve (entry, duración_encontrada, hay_desajuste). Sin duración de
+        referencia se conserva el primer resultado, como hacía la versión previa.
+        """
+        if not entries:
+            return None, None, False
+
+        if target_duration <= 0:
+            first = entries[0]
+            return first, cls._entry_duration(first), False
+
+        timed = [(e, cls._entry_duration(e)) for e in entries]
+        timed = [(e, d) for e, d in timed if d]
+        if not timed:
+            first = entries[0]
+            return first, None, False
+
+        best, best_duration = min(timed, key=lambda pair: abs(pair[1] - target_duration))
+        mismatch = abs(best_duration - target_duration) > cls.DURATION_TOLERANCE
+        return best, best_duration, mismatch
+
+    @staticmethod
+    def _entry_duration(entry: dict) -> Optional[int]:
+        duration = entry.get("duration")
+        try:
+            return int(float(duration)) if duration else None
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _clear_temp_dir(temp_dir: Path) -> None:
+        """Borra los restos de un intento fallido antes de reintentar."""
+        for leftover in temp_dir.glob("*"):
+            try:
+                if leftover.is_file():
+                    leftover.unlink()
+            except OSError:
+                pass
+
+    @staticmethod
+    def _locate_output_file(temp_dir: Path, expected_ext: str) -> Path:
+        """
+        Localiza el archivo convertido por FFmpeg. Solo acepta audio real: mover un
+        `.part` o un contenedor sin convertir dejaría un archivo corrupto con la
+        extensión equivocada.
+        """
+        exact = sorted(temp_dir.glob(f"*.{expected_ext}"))
+        if exact:
+            return exact[0]
+
+        others = [
+            p for p in sorted(temp_dir.glob("*.*"))
+            if p.suffix.lower().lstrip(".") in KNOWN_AUDIO_EXTENSIONS
+        ]
+        if others:
+            raise FileNotFoundError(
+                f"FFmpeg no generó un archivo .{expected_ext} "
+                f"(se encontró {others[0].name}); revisa que FFmpeg soporte ese códec"
+            )
+
+        raise FileNotFoundError(
+            "No se encontró el archivo de audio procesado por FFmpeg"
+        )
+
+    @classmethod
+    def download_track(
+        cls,
+        track: TrackMetadata,
+        audio_format: Optional[AudioFormat] = None,
+        output_dir: Optional[Path] = None,
+        progress_callback: Optional[Callable[[float, str], None]] = None,
+        overwrite: bool = False,
+        include_lyrics: Optional[bool] = None,
+        include_cover: Optional[bool] = None,
+    ) -> Tuple[Optional[Path], bool]:
+        """
+        Downloads a track, converts it, embeds metadata & cover art, and writes .lrc.
+        """
+        fmt = audio_format or config.default_format
+        dest_dir = output_dir or config.download_directory
+        final_path = format_track_path(track, dest_dir, fmt, config.folder_template)
+
+        # Duplicate check
+        if not overwrite and final_path.exists() and final_path.stat().st_size > 1024:
+            if progress_callback:
+                progress_callback(100.0, f"Ya existe en disco: {final_path.name}")
+            return final_path, False
+
+        # Resolve cover flag
+        should_embed_cover = config.embed_cover if include_cover is None else include_cover
+
+        # Las banderas explícitas (--lyrics / --no-lyrics, o la opción "c" del TUI)
+        # mandan sobre la configuración guardada.
+        should_save_lrc = config.save_lrc_file if include_lyrics is None else include_lyrics
+        should_embed_lyrics = config.embed_lyrics if include_lyrics is None else include_lyrics
+        should_get_lyrics = should_save_lrc or should_embed_lyrics
+
+        # Construct query for highest precision match
+        query = f"{track.artist} - {track.title} audio"
+        if track.album and track.album != track.title:
+            query = f"{track.artist} - {track.title} {track.album} audio"
+
+        with tempfile.TemporaryDirectory() as temp_dir_str:
+            temp_dir = Path(temp_dir_str)
+
+            def ytdl_hook(d):
+                if progress_callback and d.get("status") == "downloading":
+                    total = d.get("total_bytes") or d.get("total_bytes_estimate") or 0
+                    downloaded = d.get("downloaded_bytes", 0)
+                    percent = (downloaded / total * 100) if total > 0 else 50.0
+                    speed = d.get("_speed_str", "")
+                    progress_callback(percent, f"Descargando stream {speed}...")
+                elif progress_callback and d.get("status") == "finished":
+                    progress_callback(90.0, "Procesando audio y metadatos...")
+
+            try:
+                if progress_callback:
+                    progress_callback(5.0, "Buscando la versión correcta...")
+
+                # 1. Elegir el resultado cuya duración coincida con la del catálogo,
+                #    para no acabar con un radio edit o un directo por error.
+                entries = cls._search_candidates(query, cls.SEARCH_CANDIDATES)
+                if not entries:
+                    entries = cls._search_candidates(
+                        f"{track.artist} {track.title}", cls.SEARCH_CANDIDATES
+                    )
+
+                entry, matched_duration, mismatch = cls._pick_best_candidate(
+                    entries, track.duration_seconds
+                )
+
+                if entry and mismatch and progress_callback:
+                    progress_callback(
+                        8.0,
+                        f"Aviso: sin coincidencia exacta de duración "
+                        f"({matched_duration}s vs {track.duration_seconds}s)"
+                    )
+
+                # 2. Descargar el candidato elegido (o caer a la búsqueda directa).
+                download_target = None
+                if entry:
+                    download_target = entry.get("webpage_url") or entry.get("url")
+                if not download_target:
+                    download_target = f"ytsearch1:{query}"
+                    matched_duration = None
+
+                if progress_callback:
+                    progress_callback(10.0, "Obteniendo el stream de audio...")
+
+                last_error = None
+                for profile_index, (profile_name, extractor_args) in enumerate(cls.DOWNLOAD_PROFILES):
+                    cls._clear_temp_dir(temp_dir)
+                    opts = cls._create_yt_dlp_params(temp_dir, fmt, ytdl_hook, extractor_args)
+                    try:
+                        with yt_dlp.YoutubeDL(opts) as ydl:
+                            ydl.extract_info(download_target, download=True)
+                        last_error = None
+                        if profile_index > 0 and progress_callback:
+                            progress_callback(92.0, f"Usando {profile_name}")
+                        break
+                    except Exception as err:
+                        last_error = err
+
+                if last_error is not None:
+                    raise last_error
+
+                # Locate converted file in temp_dir
+                source_temp_file = cls._locate_output_file(temp_dir, fmt.extension)
+
+                # Move to final path
+                final_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(source_temp_file), str(final_path))
+
+                # Fetch and embed lyrics if enabled
+                if should_get_lyrics:
+                    if progress_callback:
+                        progress_callback(95.0, "Obteniendo letras sincronizadas...")
+                    # La duración real del audio manda: es la que sincroniza el .lrc.
+                    lyrics_data = LyricsManager.fetch_lyrics(
+                        track, duration_hint=matched_duration
+                    )
+                    if lyrics_data:
+                        track.lyrics = lyrics_data
+                        if should_save_lrc:
+                            LyricsManager.save_lrc_file(lyrics_data, final_path)
+
+                # Tag metadata and cover art
+                if progress_callback:
+                    progress_callback(98.0, "Incrustando portada HD y metadatos...")
+                MetadataTagger.apply_metadata(
+                    final_path,
+                    track,
+                    fmt,
+                    embed_cover=should_embed_cover,
+                    embed_lyrics=should_embed_lyrics
+                )
+
+                if progress_callback:
+                    progress_callback(100.0, f"Completado: {final_path.name}")
+
+                return final_path, True
+
+            except Exception as e:
+                if progress_callback:
+                    progress_callback(0.0, f"Error: {e}")
+                print(f"[Error] Falló la descarga de {track.title}: {e}")
+                return None, False

--- a/cli/monochrome_cli/core/lyrics.py
+++ b/cli/monochrome_cli/core/lyrics.py
@@ -1,0 +1,124 @@
+"""
+Lyrics fetcher and .lrc file manager for Monochrome CLI.
+"""
+import urllib.error
+import urllib.parse
+import urllib.request
+import json
+from pathlib import Path
+from typing import List, Optional
+from monochrome_cli.types import LyricsData, TrackMetadata
+
+
+class LyricsManager:
+    LRCLIB_API = "https://lrclib.net/api"
+    # Margen para dar por buena la duración de un resultado de búsqueda.
+    DURATION_TOLERANCE = 4
+
+    @classmethod
+    def fetch_lyrics(
+        cls,
+        track: TrackMetadata,
+        duration_hint: Optional[int] = None
+    ) -> Optional[LyricsData]:
+        """
+        Fetches synced (.lrc) and plain lyrics from LRCLIB.
+
+        `duration_hint` es la duración real del audio descargado. Si se indica,
+        manda sobre la del catálogo: es la que garantiza que los tiempos del .lrc
+        encajen con el archivo que el usuario acaba de guardar.
+        """
+        duration = duration_hint or track.duration_seconds
+
+        try:
+            # 1. Try exact match by track_name, artist_name, album_name, duration
+            params = {
+                "track_name": track.title,
+                "artist_name": track.artist,
+            }
+            if track.album:
+                params["album_name"] = track.album
+            if duration and duration > 0:
+                params["duration"] = str(duration)
+
+            url = f"{cls.LRCLIB_API}/get?{urllib.parse.urlencode(params)}"
+            req = urllib.request.Request(url, headers={"User-Agent": "MonochromeCLI/1.0"})
+
+            try:
+                with urllib.request.urlopen(req, timeout=6) as response:
+                    if response.status == 200:
+                        data = json.loads(response.read().decode("utf-8"))
+                        return LyricsData(
+                            plain_lyrics=data.get("plainLyrics"),
+                            synced_lyrics=data.get("syncedLyrics"),
+                            instrumental=bool(data.get("instrumental", False)),
+                            source="lrclib_exact"
+                        )
+            except urllib.error.HTTPError:
+                # 404 = sin coincidencia exacta; cualquier otro error también cae
+                # al buscador libre de abajo.
+                pass
+
+            # 2. Fallback: Search by free-form query
+            search_query = f"{track.artist} {track.title}"
+            search_url = f"{cls.LRCLIB_API}/search?{urllib.parse.urlencode({'q': search_query})}"
+            sreq = urllib.request.Request(search_url, headers={"User-Agent": "MonochromeCLI/1.0"})
+
+            with urllib.request.urlopen(sreq, timeout=6) as sresponse:
+                if sresponse.status == 200:
+                    results = json.loads(sresponse.read().decode("utf-8"))
+                    if isinstance(results, list) and results:
+                        best = cls._pick_closest(results, duration)
+                        return LyricsData(
+                            plain_lyrics=best.get("plainLyrics"),
+                            synced_lyrics=best.get("syncedLyrics"),
+                            instrumental=bool(best.get("instrumental", False)),
+                            source="lrclib_search"
+                        )
+        except Exception:
+            pass
+
+        return None
+
+    @classmethod
+    def _pick_closest(cls, results: List[dict], duration: Optional[int]) -> dict:
+        """
+        Elige el resultado con la duración más parecida a la del audio real. Sin
+        duración de referencia se conserva el primero, que es el mejor ranqueado.
+        """
+        if not duration or duration <= 0:
+            return results[0]
+
+        timed = []
+        for item in results:
+            try:
+                item_duration = int(float(item.get("duration") or 0))
+            except (TypeError, ValueError):
+                continue
+            if item_duration > 0:
+                timed.append((item, abs(item_duration - duration)))
+
+        if not timed:
+            return results[0]
+
+        # Una letra cuya duración se aleja mucho es casi seguro de otra versión;
+        # aun así es mejor que nada, así que se devuelve la más cercana.
+        best, _ = min(timed, key=lambda pair: pair[1])
+        return best
+
+    @classmethod
+    def save_lrc_file(cls, lyrics: LyricsData, audio_file_path: Path) -> Optional[Path]:
+        """
+        Saves a .lrc file alongside the audio file if synced lyrics exist.
+        """
+        content = lyrics.synced_lyrics or lyrics.plain_lyrics
+        if not content:
+            return None
+
+        lrc_path = audio_file_path.with_suffix(".lrc")
+        try:
+            with open(lrc_path, "w", encoding="utf-8") as f:
+                f.write(content.strip() + "\n")
+            return lrc_path
+        except Exception:
+            return None

--- a/cli/monochrome_cli/core/search.py
+++ b/cli/monochrome_cli/core/search.py
@@ -1,0 +1,255 @@
+"""
+Unified search engine for Monochrome CLI.
+Queries Tidal API and Deezer API for metadata, HD covers, and tracks.
+"""
+import base64
+import json
+import time
+import urllib.parse
+import urllib.request
+from typing import List, Optional
+
+from monochrome_cli.config import config
+from monochrome_cli.types import AlbumMetadata, SearchResult, TrackMetadata
+
+
+class SearchEngine:
+    _tidal_token: Optional[str] = None
+    _token_expiry: float = 0
+
+    @classmethod
+    def get_tidal_token(cls) -> Optional[str]:
+        if cls._tidal_token and time.time() < cls._token_expiry:
+            return cls._tidal_token
+
+        client_id = config.tidal_client_id
+        client_secret = config.tidal_client_secret
+
+        try:
+            auth_header = "Basic " + base64.b64encode(f"{client_id}:{client_secret}".encode()).decode()
+            data = urllib.parse.urlencode({
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "grant_type": "client_credentials"
+            }).encode()
+
+            req = urllib.request.Request(
+                "https://auth.tidal.com/v1/oauth2/token",
+                data=data,
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "Authorization": auth_header
+                }
+            )
+            with urllib.request.urlopen(req, timeout=8) as res:
+                if res.status == 200:
+                    token_data = json.loads(res.read().decode("utf-8"))
+                    cls._tidal_token = token_data.get("access_token")
+                    expires_in = token_data.get("expires_in", 3600)
+                    cls._token_expiry = time.time() + expires_in - 60
+                    return cls._tidal_token
+        except Exception:
+            pass
+        return None
+
+    @classmethod
+    def format_tidal_cover(cls, cover_id: Optional[str], size: int = 1280) -> Optional[str]:
+        if not cover_id:
+            return None
+        formatted = str(cover_id).replace("-", "/")
+        return f"https://resources.tidal.com/images/{formatted}/{size}x{size}.jpg"
+
+    @classmethod
+    def search_tidal_tracks(cls, query: str, limit: int = 15) -> List[TrackMetadata]:
+        token = cls.get_tidal_token()
+        if not token:
+            return []
+
+        try:
+            params = urllib.parse.urlencode({
+                "query": query,
+                "countryCode": config.country_code,
+                "limit": limit
+            })
+            url = f"https://api.tidal.com/v1/search/tracks?{params}"
+            req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+
+            with urllib.request.urlopen(req, timeout=8) as res:
+                if res.status == 200:
+                    data = json.loads(res.read().decode("utf-8"))
+                    items = data.get("items", [])
+                    tracks = []
+                    for item in items:
+                        artists = ", ".join([a.get("name", "") for a in item.get("artists", [])]) or item.get("artist", {}).get("name", "Unknown Artist")
+                        album_data = item.get("album", {})
+                        cover_id = album_data.get("cover") or item.get("cover")
+                        cover_url = cls.format_tidal_cover(cover_id, config.cover_resolution)
+                        release_date = album_data.get("releaseDate") or item.get("streamStartDate") or ""
+                        year = release_date.split("-")[0] if release_date else ""
+
+                        tracks.append(TrackMetadata(
+                            title=item.get("title", ""),
+                            artist=artists,
+                            album=album_data.get("title", ""),
+                            album_artist=album_data.get("artist", {}).get("name") or artists,
+                            duration_seconds=int(item.get("duration", 0)),
+                            track_number=int(item.get("trackNumber", 1)),
+                            disc_number=int(item.get("volumeNumber", 1)),
+                            year=year,
+                            release_date=release_date,
+                            isrc=item.get("isrc"),
+                            explicit=bool(item.get("explicit", False)),
+                            cover_url=cover_url,
+                            source="tidal",
+                            source_id=str(item.get("id"))
+                        ))
+                    return tracks
+        except Exception:
+            pass
+        return []
+
+    @classmethod
+    def search_deezer_tracks(cls, query: str, limit: int = 15) -> List[TrackMetadata]:
+        try:
+            params = urllib.parse.urlencode({"q": query, "limit": limit})
+            url = f"https://api.deezer.com/search?{params}"
+            req = urllib.request.Request(url, headers={"User-Agent": "MonochromeCLI/1.0"})
+
+            with urllib.request.urlopen(req, timeout=8) as res:
+                if res.status == 200:
+                    data = json.loads(res.read().decode("utf-8"))
+                    items = data.get("data", [])
+                    tracks = []
+                    for item in items:
+                        album_data = item.get("album", {})
+                        artist_data = item.get("artist", {})
+                        cover_url = album_data.get("cover_xl") or album_data.get("cover_big") or album_data.get("cover_medium")
+
+                        tracks.append(TrackMetadata(
+                            title=item.get("title", ""),
+                            artist=artist_data.get("name", "Unknown Artist"),
+                            album=album_data.get("title", ""),
+                            album_artist=artist_data.get("name", "Unknown Artist"),
+                            duration_seconds=int(item.get("duration", 0)),
+                            track_number=int(item.get("track_position", 1) or 1),
+                            disc_number=int(item.get("disk_number", 1) or 1),
+                            cover_url=cover_url,
+                            explicit=bool(item.get("explicit_lyrics", False)),
+                            source="deezer",
+                            source_id=str(item.get("id"))
+                        ))
+                    return tracks
+        except Exception:
+            pass
+        return []
+
+    @classmethod
+    def search_tidal_albums(cls, query: str, limit: int = 10) -> List[AlbumMetadata]:
+        token = cls.get_tidal_token()
+        if not token:
+            return []
+
+        try:
+            params = urllib.parse.urlencode({
+                "query": query,
+                "countryCode": config.country_code,
+                "limit": limit
+            })
+            url = f"https://api.tidal.com/v1/search/albums?{params}"
+            req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+
+            with urllib.request.urlopen(req, timeout=8) as res:
+                if res.status == 200:
+                    data = json.loads(res.read().decode("utf-8"))
+                    items = data.get("items", [])
+                    albums = []
+                    for item in items:
+                        artists = ", ".join([a.get("name", "") for a in item.get("artists", [])]) or item.get("artist", {}).get("name", "Unknown Artist")
+                        cover_id = item.get("cover")
+                        cover_url = cls.format_tidal_cover(cover_id, config.cover_resolution)
+                        release_date = item.get("releaseDate") or ""
+                        year = release_date.split("-")[0] if release_date else ""
+
+                        albums.append(AlbumMetadata(
+                            title=item.get("title", ""),
+                            artist=artists,
+                            release_date=release_date,
+                            year=year,
+                            cover_url=cover_url,
+                            total_tracks=int(item.get("numberOfTracks", 0)),
+                            source="tidal",
+                            source_id=str(item.get("id"))
+                        ))
+                    return albums
+        except Exception:
+            pass
+        return []
+
+    @classmethod
+    def get_album_tracks(cls, album_id: str) -> List[TrackMetadata]:
+        """Fetches all tracks belonging to an album."""
+        token = cls.get_tidal_token()
+        if not token:
+            return []
+
+        try:
+            url = (
+                f"https://api.tidal.com/v1/albums/{album_id}/items"
+                f"?countryCode={config.country_code}&limit=100"
+            )
+            req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+
+            with urllib.request.urlopen(req, timeout=8) as res:
+                if res.status == 200:
+                    data = json.loads(res.read().decode("utf-8"))
+                    items = data.get("items", [])
+                    tracks = []
+                    for entry in items:
+                        item = entry.get("item", {})
+                        if not item:
+                            continue
+                        artists = ", ".join([a.get("name", "") for a in item.get("artists", [])]) or item.get("artist", {}).get("name", "Unknown Artist")
+                        album_data = item.get("album", {})
+                        cover_id = album_data.get("cover") or item.get("cover")
+                        cover_url = cls.format_tidal_cover(cover_id, config.cover_resolution)
+                        release_date = album_data.get("releaseDate") or item.get("streamStartDate") or ""
+                        year = release_date.split("-")[0] if release_date else ""
+
+                        tracks.append(TrackMetadata(
+                            title=item.get("title", ""),
+                            artist=artists,
+                            album=album_data.get("title", ""),
+                            album_artist=album_data.get("artist", {}).get("name") or artists,
+                            duration_seconds=int(item.get("duration", 0)),
+                            track_number=int(item.get("trackNumber", 1)),
+                            total_tracks=int(album_data.get("numberOfTracks", len(items))),
+                            disc_number=int(item.get("volumeNumber", 1)),
+                            year=year,
+                            release_date=release_date,
+                            isrc=item.get("isrc"),
+                            explicit=bool(item.get("explicit", False)),
+                            cover_url=cover_url,
+                            source="tidal",
+                            source_id=str(item.get("id"))
+                        ))
+                    return tracks
+        except Exception:
+            pass
+        return []
+
+    @classmethod
+    def search(cls, query: str, limit: Optional[int] = None) -> SearchResult:
+        lim = limit or config.search_limit
+
+        # 1. Search tracks on Tidal
+        tidal_tracks = cls.search_tidal_tracks(query, limit=lim)
+        if not tidal_tracks:
+            # Fallback to Deezer
+            tracks = cls.search_deezer_tracks(query, limit=lim)
+        else:
+            tracks = tidal_tracks
+
+        # 2. Search albums on Tidal
+        albums = cls.search_tidal_albums(query, limit=5)
+
+        return SearchResult(tracks=tracks, albums=albums, query=query)

--- a/cli/monochrome_cli/core/tagger.py
+++ b/cli/monochrome_cli/core/tagger.py
@@ -1,0 +1,279 @@
+"""
+Audio metadata tagger using Mutagen for MP3, FLAC, M4A, and OPUS.
+Embeds High-Res covers, ID3v2.4 / Vorbis / MP4 atoms, lyrics and tags.
+"""
+import base64
+import struct
+import urllib.request
+from pathlib import Path
+from typing import Optional, Tuple
+
+from mutagen.id3 import (
+    ID3,
+    TIT2,
+    TPE1,
+    TPE2,
+    TALB,
+    TRCK,
+    TPOS,
+    TDRC,
+    TCON,
+    TSRC,
+    USLT,
+    APIC,
+    ID3NoHeaderError,
+)
+from mutagen.flac import FLAC, Picture
+from mutagen.mp4 import MP4, MP4Cover
+from mutagen.oggopus import OggOpus
+from mutagen.oggvorbis import OggVorbis
+
+from monochrome_cli.types import TrackMetadata, AudioFormat
+
+
+def is_png(data: bytes) -> bool:
+    return len(data) >= 8 and data[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+def image_dimensions(data: bytes) -> Tuple[int, int]:
+    """
+    Lee el ancho y alto de un PNG o JPEG. Los bloques de portada de Vorbis y FLAC
+    llevan estos campos; devolver 0x0 hace que algunos reproductores descarten la
+    imagen, así que merece la pena leerlos de la cabecera.
+    """
+    try:
+        if is_png(data) and len(data) >= 24:
+            width, height = struct.unpack(">II", data[16:24])
+            return int(width), int(height)
+
+        if data[:2] == b"\xff\xd8":  # JPEG
+            i = 2
+            while i + 9 < len(data):
+                if data[i] != 0xFF:
+                    i += 1
+                    continue
+                marker = data[i + 1]
+                # SOF0..SOF15, excluyendo los marcadores que no describen el frame.
+                if 0xC0 <= marker <= 0xCF and marker not in (0xC4, 0xC8, 0xCC):
+                    height, width = struct.unpack(">HH", data[i + 5:i + 9])
+                    return int(width), int(height)
+                if marker in (0xD8, 0xD9) or 0xD0 <= marker <= 0xD7:
+                    i += 2
+                    continue
+                segment_length = struct.unpack(">H", data[i + 2:i + 4])[0]
+                i += 2 + segment_length
+    except Exception:
+        pass
+    return 0, 0
+
+
+def build_picture(cover_bytes: bytes) -> Picture:
+    """Construye el bloque de imagen compartido por FLAC, Opus y OGG Vorbis."""
+    width, height = image_dimensions(cover_bytes)
+    pic = Picture()
+    pic.data = cover_bytes
+    pic.type = 3  # Front Cover
+    pic.mime = "image/png" if is_png(cover_bytes) else "image/jpeg"
+    pic.desc = "Cover"
+    pic.width = width
+    pic.height = height
+    pic.depth = 24
+    return pic
+
+
+def encode_picture_block(cover_bytes: bytes) -> str:
+    """Portada en base64 para el campo METADATA_BLOCK_PICTURE de los Ogg."""
+    return base64.b64encode(build_picture(cover_bytes).write()).decode("ascii")
+
+
+class MetadataTagger:
+    @classmethod
+    def fetch_cover_bytes(cls, cover_url: str) -> Optional[bytes]:
+        if not cover_url:
+            return None
+        try:
+            req = urllib.request.Request(
+                cover_url,
+                headers={"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"}
+            )
+            with urllib.request.urlopen(req, timeout=10) as res:
+                if res.status == 200:
+                    return res.read()
+        except Exception:
+            pass
+        return None
+
+    @classmethod
+    def apply_metadata(
+        cls,
+        file_path: Path,
+        track: TrackMetadata,
+        audio_format: AudioFormat,
+        embed_cover: bool = True,
+        embed_lyrics: bool = True
+    ) -> bool:
+        if not file_path.exists():
+            return False
+
+        ext = file_path.suffix.lower().lstrip(".")
+        cover_bytes = cls.fetch_cover_bytes(track.cover_url) if (embed_cover and track.cover_url) else None
+
+        lyrics_text = None
+        if embed_lyrics and track.lyrics:
+            lyrics_text = track.lyrics.synced_lyrics or track.lyrics.plain_lyrics
+
+        taggers = {
+            "mp3": cls._tag_mp3,
+            "flac": cls._tag_flac,
+            "m4a": cls._tag_m4a,
+            "mp4": cls._tag_m4a,
+            "aac": cls._tag_m4a,
+            "opus": cls._tag_opus,
+            "ogg": cls._tag_ogg,
+        }
+        tagger = taggers.get(ext)
+        if tagger is None:
+            print(f"[Aviso] Formato no reconocido para etiquetar: {file_path.name}")
+            return False
+
+        try:
+            tagger(file_path, track, cover_bytes, lyrics_text)
+            return True
+        except Exception as e:
+            print(f"[Aviso] No se pudieron incrustar todos los metadatos en {file_path.name}: {e}")
+            return False
+
+    @staticmethod
+    def _tag_mp3(file_path: Path, track: TrackMetadata, cover_bytes: Optional[bytes], lyrics: Optional[str]):
+        try:
+            audio = ID3(file_path)
+        except ID3NoHeaderError:
+            audio = ID3()
+
+        audio.add(TIT2(encoding=3, text=track.title))
+        audio.add(TPE1(encoding=3, text=track.artist))
+        if track.album_artist or track.artist:
+            audio.add(TPE2(encoding=3, text=track.album_artist or track.artist))
+        if track.album:
+            audio.add(TALB(encoding=3, text=track.album))
+        if track.track_number:
+            trck_str = f"{track.track_number}/{track.total_tracks}" if track.total_tracks > 1 else str(track.track_number)
+            audio.add(TRCK(encoding=3, text=trck_str))
+        if track.disc_number:
+            tpos_str = f"{track.disc_number}/{track.total_discs}" if track.total_discs > 1 else str(track.disc_number)
+            audio.add(TPOS(encoding=3, text=tpos_str))
+        if track.year:
+            audio.add(TDRC(encoding=3, text=str(track.year)))
+        if track.genre:
+            audio.add(TCON(encoding=3, text=track.genre))
+        if track.isrc:
+            audio.add(TSRC(encoding=3, text=track.isrc))
+
+        if lyrics:
+            audio.add(USLT(encoding=3, lang="eng", desc="Lyrics", text=lyrics))
+
+        if cover_bytes:
+            mime = "image/png" if is_png(cover_bytes) else "image/jpeg"
+            audio.add(APIC(
+                encoding=3,
+                mime=mime,
+                type=3,  # Front Cover
+                desc="Cover",
+                data=cover_bytes
+            ))
+
+        audio.save(file_path, v2_version=4)
+
+    @staticmethod
+    def _tag_flac(file_path: Path, track: TrackMetadata, cover_bytes: Optional[bytes], lyrics: Optional[str]):
+        audio = FLAC(file_path)
+        audio["TITLE"] = track.title
+        audio["ARTIST"] = track.artist
+        if track.album_artist or track.artist:
+            audio["ALBUMARTIST"] = track.album_artist or track.artist
+        if track.album:
+            audio["ALBUM"] = track.album
+        if track.track_number:
+            audio["TRACKNUMBER"] = str(track.track_number)
+        if track.total_tracks:
+            audio["TRACKTOTAL"] = str(track.total_tracks)
+        if track.disc_number:
+            audio["DISCNUMBER"] = str(track.disc_number)
+        if track.total_discs:
+            audio["DISCTOTAL"] = str(track.total_discs)
+        if track.year:
+            audio["DATE"] = str(track.year)
+        if track.genre:
+            audio["GENRE"] = track.genre
+        if track.isrc:
+            audio["ISRC"] = track.isrc
+        if lyrics:
+            audio["LYRICS"] = lyrics
+
+        if cover_bytes:
+            audio.clear_pictures()
+            audio.add_picture(build_picture(cover_bytes))
+
+        audio.save()
+
+    @staticmethod
+    def _tag_m4a(file_path: Path, track: TrackMetadata, cover_bytes: Optional[bytes], lyrics: Optional[str]):
+        audio = MP4(file_path)
+        audio["\xa9nam"] = track.title
+        audio["\xa9ART"] = track.artist
+        audio["aART"] = track.album_artist or track.artist
+        if track.album:
+            audio["\xa9alb"] = track.album
+        if track.track_number:
+            audio["trkn"] = [(track.track_number, track.total_tracks or 0)]
+        if track.disc_number:
+            audio["disk"] = [(track.disc_number, track.total_discs or 0)]
+        if track.year:
+            audio["\xa9day"] = str(track.year)
+        if track.genre:
+            audio["\xa9gen"] = track.genre
+        if lyrics:
+            audio["\xa9lyr"] = lyrics
+
+        if cover_bytes:
+            fmt = MP4Cover.FORMAT_PNG if is_png(cover_bytes) else MP4Cover.FORMAT_JPEG
+            audio["covr"] = [MP4Cover(cover_bytes, imageformat=fmt)]
+
+        audio.save()
+
+    @classmethod
+    def _tag_opus(cls, file_path: Path, track: TrackMetadata, cover_bytes: Optional[bytes], lyrics: Optional[str]):
+        cls._tag_vorbis_comments(OggOpus(file_path), track, cover_bytes, lyrics)
+
+    @classmethod
+    def _tag_ogg(cls, file_path: Path, track: TrackMetadata, cover_bytes: Optional[bytes], lyrics: Optional[str]):
+        cls._tag_vorbis_comments(OggVorbis(file_path), track, cover_bytes, lyrics)
+
+    @staticmethod
+    def _tag_vorbis_comments(audio, track: TrackMetadata, cover_bytes: Optional[bytes], lyrics: Optional[str]):
+        """Comentarios Vorbis compartidos por Opus y OGG, portada incluida."""
+        audio["title"] = track.title
+        audio["artist"] = track.artist
+        if track.album_artist or track.artist:
+            audio["albumartist"] = track.album_artist or track.artist
+        if track.album:
+            audio["album"] = track.album
+        if track.track_number:
+            audio["tracknumber"] = str(track.track_number)
+        if track.total_tracks:
+            audio["tracktotal"] = str(track.total_tracks)
+        if track.disc_number:
+            audio["discnumber"] = str(track.disc_number)
+        if track.year:
+            audio["date"] = str(track.year)
+        if track.genre:
+            audio["genre"] = track.genre
+        if track.isrc:
+            audio["isrc"] = track.isrc
+        if lyrics:
+            audio["lyrics"] = lyrics
+
+        if cover_bytes:
+            audio["metadata_block_picture"] = [encode_picture_block(cover_bytes)]
+
+        audio.save()

--- a/cli/monochrome_cli/main.py
+++ b/cli/monochrome_cli/main.py
@@ -1,0 +1,555 @@
+"""
+Main entry point and Interactive TUI for Monochrome CLI.
+"""
+import argparse
+import sys
+from pathlib import Path
+from typing import Any, List, NamedTuple, Optional, Tuple
+
+from rich.console import Console
+from rich.prompt import Prompt
+
+from monochrome_cli.config import config
+from monochrome_cli.core.downloader import Downloader
+from monochrome_cli.core.search import SearchEngine
+from monochrome_cli.types import AudioFormat, TrackMetadata
+from monochrome_cli.ui.banner import print_banner
+from monochrome_cli.ui.tables import (
+    display_albums_table,
+    display_formats_table,
+    display_settings_table,
+    display_tracks_table,
+)
+from monochrome_cli.utils.platform import ffmpeg_install_hint, find_ffmpeg
+
+console = Console()
+
+AFFIRMATIVE = ("s", "si", "sí", "y", "yes")
+
+
+class DownloadChoice(NamedTuple):
+    """Opciones elegidas para una descarga concreta."""
+    audio_format: Optional[AudioFormat]
+    lyrics: Optional[bool]
+    overwrite: bool
+
+
+def is_yes(answer: str) -> bool:
+    return answer.strip().lower() in AFFIRMATIVE
+
+
+def require_ffmpeg() -> bool:
+    """
+    Comprueba FFmpeg antes de descargar. Sin él yt-dlp falla al convertir y el
+    error que llega al usuario no dice qué falta.
+    """
+    if find_ffmpeg():
+        return True
+    console.print(
+        "[bold red]✗ FFmpeg no está instalado.[/bold red] Es imprescindible para "
+        "convertir el audio descargado.\n"
+        f"  Instálalo con: [bold yellow]{ffmpeg_install_hint()}[/bold yellow]\n"
+    )
+    return False
+
+
+def parse_selection(selection: str, track_count: int, album_count: int) -> Tuple[str, Any]:
+    """
+    Interpreta lo que el usuario escribe en la lista de resultados.
+
+    Devuelve (acción, dato) donde acción es "quit", "search", "tracks" (dato =
+    índices 0-based), "album" (dato = índice 0-based) o "error" (dato = mensaje).
+    Está separada del bucle interactivo para poder probarla sin terminal.
+    """
+    selection = (selection or "").strip()
+    if not selection:
+        return "error", "No escribiste ninguna opción."
+
+    lowered = selection.lower()
+    if lowered in ("q", "quit", "exit", "salir"):
+        return "quit", None
+    if lowered in ("s", "search", "n", "buscar"):
+        return "search", None
+
+    if lowered == "all":
+        if not track_count:
+            return "error", "No hay canciones que descargar."
+        return "tracks", list(range(track_count))
+
+    # Álbum: A1, a2...
+    if lowered.startswith("a") and selection[1:].strip().isdigit():
+        idx = int(selection[1:].strip()) - 1
+        if not album_count:
+            return "error", "Esta búsqueda no devolvió álbumes."
+        if not 0 <= idx < album_count:
+            return "error", f"Álbum fuera de rango (A1-A{album_count})."
+        return "album", idx
+
+    def validate(numbers: List[int]) -> Tuple[str, Any]:
+        valid = [n - 1 for n in numbers if 1 <= n <= track_count]
+        invalid = sorted({n for n in numbers if not 1 <= n <= track_count})
+        if not valid:
+            return "error", f"Ningún número válido. El rango disponible es 1-{track_count}."
+        if invalid:
+            console.print(
+                f"[yellow]Se ignoraron números fuera de rango: "
+                f"{', '.join(str(n) for n in invalid)} (disponible 1-{track_count})[/yellow]"
+            )
+        # dict.fromkeys conserva el orden y descarta repetidos
+        return "tracks", list(dict.fromkeys(valid))
+
+    # Rango: 1-5
+    if "-" in selection:
+        start_str, _, end_str = selection.partition("-")
+        start_str, end_str = start_str.strip(), end_str.strip()
+        if start_str.isdigit() and end_str.isdigit():
+            start, end = int(start_str), int(end_str)
+            if start > end:
+                start, end = end, start
+            return validate(list(range(start, end + 1)))
+        return "error", "Rango inválido. Usa un formato como 1-3."
+
+    # Lista: 1, 3, 5
+    if "," in selection:
+        parts = [p.strip() for p in selection.split(",") if p.strip()]
+        if not all(p.isdigit() for p in parts):
+            return "error", "Lista inválida. Usa un formato como 1,3,5."
+        return validate([int(p) for p in parts])
+
+    if selection.isdigit():
+        return validate([int(selection)])
+
+    return "error", "Opción no reconocida. Escribe un número, un rango (1-3), 'all', 'A1' o 's'."
+
+
+def download_single_track(
+    track: TrackMetadata,
+    audio_format: Optional[AudioFormat] = None,
+    output_dir: Optional[Path] = None,
+    overwrite: bool = False,
+    include_lyrics: Optional[bool] = None,
+):
+    fmt = audio_format or config.default_format
+    lyrics_active = config.embed_lyrics if include_lyrics is None else include_lyrics
+    lyrics_str = "Con Letras (.lrc)" if lyrics_active else "Sin Letras"
+    console.print(f"\n[bold green]⬇ Iniciando descarga:[/bold green] [white]{track.artist} - {track.title}[/white] [{fmt.value.upper()} | {lyrics_str}]")
+
+    with console.status("[bold cyan]Procesando stream y metadatos...", spinner="dots") as status:
+        def update_status(pct: float, msg: str):
+            status.update(f"[bold cyan]{msg} ({pct:.0f}%)[/bold cyan]")
+
+        saved_file, is_new = Downloader.download_track(
+            track,
+            fmt,
+            output_dir=output_dir,
+            progress_callback=update_status,
+            overwrite=overwrite,
+            include_lyrics=include_lyrics
+        )
+
+    if saved_file:
+        if is_new:
+            console.print(f"[bold green]✔ Guardado con éxito en:[/bold green] [yellow]{saved_file}[/yellow]\n")
+        else:
+            console.print(f"[bold yellow]⚡ Ya descargada (Omitida para evitar duplicados):[/bold yellow] [dim]{saved_file}[/dim]\n")
+    else:
+        console.print(f"[bold red]✗ No se pudo completar la descarga de {track.title}[/bold red]\n")
+
+
+def download_batch_tracks(
+    tracks: List[TrackMetadata],
+    audio_format: Optional[AudioFormat] = None,
+    output_dir: Optional[Path] = None,
+    overwrite: bool = False,
+    include_lyrics: Optional[bool] = None,
+):
+    fmt = audio_format or config.default_format
+    total = len(tracks)
+    lyrics_active = config.embed_lyrics if include_lyrics is None else include_lyrics
+    lyrics_str = "Con Letras (.lrc)" if lyrics_active else "Sin Letras"
+    console.print(f"\n[bold cyan]📦 Descargando lote de {total} canciones en formato {fmt.value.upper()} [{lyrics_str}]...[/bold cyan]\n")
+
+    new_count = 0
+    skipped_count = 0
+    failed_count = 0
+
+    for i, track in enumerate(tracks, 1):
+        console.print(f"[bold yellow][{i}/{total}][/bold yellow] [white]{track.artist} - {track.title}[/white]")
+        try:
+            with console.status(f"[bold cyan]Descargando [{i}/{total}]...", spinner="dots") as status:
+                def update_status(pct: float, msg: str):
+                    status.update(f"[bold cyan]{msg} ({pct:.0f}%)[/bold cyan]")
+                saved_file, is_new = Downloader.download_track(
+                    track,
+                    fmt,
+                    output_dir=output_dir,
+                    progress_callback=update_status,
+                    overwrite=overwrite,
+                    include_lyrics=include_lyrics
+                )
+        except KeyboardInterrupt:
+            # Cancelar un lote no debería perder lo ya descargado.
+            console.print(f"\n[yellow]Lote interrumpido en la pista {i} de {total}.[/yellow]")
+            break
+
+        if saved_file:
+            if is_new:
+                new_count += 1
+                console.print(f"  [green]✔ Descargado:[/green] [dim]{saved_file.name}[/dim]")
+            else:
+                skipped_count += 1
+                console.print(f"  [yellow]⚡ Ya existía (Omitido):[/yellow] [dim]{saved_file.name}[/dim]")
+        else:
+            failed_count += 1
+            console.print(f"  [red]✗ Error al descargar pista {i}[/red]")
+
+    summary = f"[bold green]✔ ¡Lote finalizado! Nuevas: {new_count} | Omitidas: {skipped_count}"
+    if failed_count:
+        summary += f" | [bold red]Fallidas: {failed_count}[/bold red]"
+    console.print(f"\n{summary}[/bold green]\n")
+
+
+def select_format_menu(prompt_title: str = "Selecciona Formato") -> AudioFormat:
+    display_formats_table()
+    choice = Prompt.ask(f"[bold yellow]{prompt_title} (1-6)[/bold yellow]", choices=["1", "2", "3", "4", "5", "6"], default="1")
+    mapping = {
+        "1": AudioFormat.FLAC,
+        "2": AudioFormat.MP3_320,
+        "3": AudioFormat.MP3_256,
+        "4": AudioFormat.M4A_256,
+        "5": AudioFormat.OPUS_160,
+        "6": AudioFormat.MP3_128,
+    }
+    return mapping.get(choice, AudioFormat.MP3_320)
+
+
+def change_format_interactive():
+    selected_fmt = select_format_menu("Elige el nuevo formato por defecto")
+    config.default_format = selected_fmt
+    console.print(f"[bold green]✔ Formato predeterminado establecido a: {config.default_format.display_name}[/bold green]\n")
+
+
+def configure_settings_interactive():
+    while True:
+        display_settings_table()
+        console.print("[bold cyan]Menú de Configuración y Preferencias:[/bold cyan]")
+        console.print("  [yellow]1[/yellow] - Cambiar Carpeta de Descargas Predeterminada")
+        console.print("  [yellow]2[/yellow] - Cambiar Formato y Calidad de Audio Predeterminada")
+        console.print("  [yellow]3[/yellow] - Activar / Desactivar Letras Sincronizadas (.lrc e incrustadas)")
+        console.print("  [yellow]4[/yellow] - Activar / Desactivar Incrustación de Portadas HD")
+        console.print("  [yellow]5[/yellow] - Cambiar Resolución de Portada (1280x1280, 1400x1400, 640x640)")
+        console.print("  [yellow]6[/yellow] - Cambiar Plantilla de Carpetas y Nombres")
+        console.print("  [yellow]7[/yellow] - Cambiar País del Catálogo (afecta a qué ediciones aparecen)")
+        console.print("  [yellow]8[/yellow] - Restaurar Valores de Fábrica")
+        console.print("  [yellow]q[/yellow] - Volver al Menú Principal\n")
+
+        ans = Prompt.ask("[bold yellow]Selecciona una opción (1-8 o q)[/bold yellow]", default="q").strip()
+        if ans == "1":
+            new_dir = Prompt.ask("Nueva ruta de descargas", default=str(config.download_directory))
+            config.download_directory = new_dir
+            console.print(f"[bold green]✔ Carpeta predeterminada: {config.download_directory}[/bold green]\n")
+        elif ans == "2":
+            change_format_interactive()
+        elif ans == "3":
+            new_state = not config.embed_lyrics
+            config.update({"embed_lyrics": new_state, "save_lrc_file": new_state})
+            status_text = "ACTIVADA (Guardará archivo .lrc e incrustará en audio)" if new_state else "DESACTIVADA"
+            console.print(f"[bold green]✔ Descarga de Letras Sincronizadas: {status_text}[/bold green]\n")
+        elif ans == "4":
+            new_state = not config.embed_cover
+            config.set("embed_cover", new_state)
+            status_text = "ACTIVADO" if new_state else "DESACTIVADO"
+            console.print(f"[bold green]✔ Incrustar portadas HD: {status_text}[/bold green]\n")
+        elif ans == "5":
+            res_choice = Prompt.ask("Resolución de carátula", choices=["640", "1280", "1400"], default="1280")
+            config.set("cover_resolution", int(res_choice))
+            console.print(f"[bold green]✔ Resolución de portada establecida a: {config.cover_resolution}x{config.cover_resolution} px[/bold green]\n")
+        elif ans == "6":
+            console.print("[dim]Variables: {album_artist}, {artist}, {album}, {title}, {year}, {track_number:02d}[/dim]")
+            new_tmpl = Prompt.ask("Nueva plantilla", default=config.folder_template)
+            config.set("folder_template", new_tmpl)
+            console.print(f"[bold green]✔ Plantilla actualizada: {config.folder_template}[/bold green]\n")
+        elif ans == "7":
+            new_country = Prompt.ask(
+                "Código de país ISO de 2 letras (US, ES, MX, AR...)",
+                default=config.country_code
+            ).strip().upper()
+            if len(new_country) == 2 and new_country.isalpha():
+                config.set("country_code", new_country)
+                console.print(f"[bold green]✔ País del catálogo: {config.country_code}[/bold green]\n")
+            else:
+                console.print("[red]Código inválido: deben ser 2 letras, por ejemplo ES.[/red]\n")
+        elif ans == "8":
+            confirm = Prompt.ask("[bold red]¿Restaurar toda la configuración por defecto? (s/n)[/bold red]", default="n")
+            if is_yes(confirm):
+                config.reset_to_defaults()
+                console.print("[bold green]✔ Configuración restaurada a valores de fábrica.[/bold green]\n")
+        elif ans.lower() in ("q", "quit", "exit", "volver"):
+            break
+
+
+def ask_download_customization() -> DownloadChoice:
+    """
+    Allows customizing format, lyrics and overwrite for a specific download.
+    """
+    lyrics_status = "Sí" if config.embed_lyrics else "No"
+    console.print(f"\n[bold cyan]Opciones de Descarga Actuales:[/bold cyan] Formato=[yellow]{config.default_format.display_name}[/yellow] | Letras=[yellow]{lyrics_status}[/yellow]")
+    custom_ans = Prompt.ask(
+        "[bold yellow]¿Descargar con opciones actuales [Enter] o [c]ustomizar formato/letras?[/bold yellow]",
+        default="d"
+    ).strip().lower()
+
+    if custom_ans == "c":
+        chosen_fmt = select_format_menu("Elige el formato para esta descarga")
+        lyrics_choice = is_yes(Prompt.ask("¿Descargar letras sincronizadas (.lrc)? (s/n)", default="s"))
+        overwrite_choice = is_yes(Prompt.ask("¿Volver a descargar si el archivo ya existe? (s/n)", default="n"))
+        make_default = is_yes(Prompt.ask("¿Guardar estas opciones como tus nuevas opciones predeterminadas? (s/n)", default="n"))
+        if make_default:
+            config.update({
+                "default_format": chosen_fmt.value,
+                "embed_lyrics": lyrics_choice,
+                "save_lrc_file": lyrics_choice,
+            })
+            console.print("[bold green]✔ ¡Nuevos valores guardados como predeterminados![/bold green]")
+        return DownloadChoice(chosen_fmt, lyrics_choice, overwrite_choice)
+
+    return DownloadChoice(config.default_format, config.embed_lyrics, False)
+
+
+def handle_album_selection(album, choice_provider=ask_download_customization):
+    console.print(f"\n[bold cyan]Cargando pistas del álbum '{album.title}' - {album.artist}...[/bold cyan]")
+    with console.status("[bold cyan]Obteniendo lista de canciones del álbum...", spinner="dots"):
+        album_tracks = SearchEngine.get_album_tracks(album.source_id)
+
+    if not album_tracks:
+        console.print("[red]No se pudieron cargar las pistas de este álbum.[/red]")
+        return
+
+    display_tracks_table(album_tracks, title=f"Álbum: {album.title} ({len(album_tracks)} pistas)")
+    if not is_yes(Prompt.ask("[bold yellow]¿Descargar álbum completo? (s/n)[/bold yellow]", default="s")):
+        return
+
+    choice = choice_provider()
+    download_batch_tracks(
+        album_tracks,
+        audio_format=choice.audio_format,
+        include_lyrics=choice.lyrics,
+        overwrite=choice.overwrite,
+    )
+
+
+def interactive_search_loop():
+    print_banner()
+
+    while True:
+        try:
+            query = Prompt.ask("\n[bold cyan]🔍 Buscar canción / álbum / artista (o 'config' para ajustes, 'fmt' para formato, 'q' para salir)[/bold cyan]").strip()
+
+            if not query or query.lower() in ("q", "quit", "exit"):
+                console.print("[dim]¡Hasta luego![/dim]")
+                break
+
+            if query.lower() in ("fmt", "format", "formato"):
+                change_format_interactive()
+                continue
+
+            if query.lower() in ("config", "settings", "ajustes", "opciones"):
+                configure_settings_interactive()
+                continue
+
+            with console.status(f"[bold cyan]Buscando '{query}' en el catálogo...", spinner="dots"):
+                res = SearchEngine.search(query)
+
+            if not res.tracks and not res.albums:
+                console.print("[bold red]No se encontraron resultados.[/bold red] Intenta con otro término.")
+                continue
+
+            # Display tracks and albums
+            if res.tracks:
+                display_tracks_table(res.tracks, title=f"Resultados para '{query}'")
+            if res.albums:
+                display_albums_table(res.albums, title=f"Álbumes para '{query}'")
+
+            # User Selection Prompt
+            while True:
+                prompt_text = (
+                    f"[bold yellow]Selecciona # (1-{len(res.tracks)}), 'all', rango (ej: 1-3), "
+                    f"Álbum (A1) o 's' para buscar de nuevo[/bold yellow]"
+                )
+                selection = Prompt.ask(prompt_text, default="1")
+                action, payload = parse_selection(selection, len(res.tracks), len(res.albums))
+
+                if action == "quit":
+                    return
+                if action == "search":
+                    break
+                if action == "error":
+                    console.print(f"[red]{payload}[/red]")
+                    continue
+
+                if action == "album":
+                    handle_album_selection(res.albums[payload])
+                    break
+
+                if action == "tracks":
+                    if not require_ffmpeg():
+                        break
+                    selected = [res.tracks[i] for i in payload]
+                    choice = ask_download_customization()
+                    if len(selected) == 1:
+                        download_single_track(
+                            selected[0],
+                            audio_format=choice.audio_format,
+                            include_lyrics=choice.lyrics,
+                            overwrite=choice.overwrite,
+                        )
+                    else:
+                        download_batch_tracks(
+                            selected,
+                            audio_format=choice.audio_format,
+                            include_lyrics=choice.lyrics,
+                            overwrite=choice.overwrite,
+                        )
+                    break
+
+        except KeyboardInterrupt:
+            console.print("\n[dim]Saliendo...[/dim]")
+            break
+        except Exception as e:
+            console.print(f"[bold red]Ocurrió un error inesperado:[/bold red] {e}")
+
+
+def resolve_format_argument(value: str, flag_name: str) -> AudioFormat:
+    """Convierte el formato pedido por línea de comandos, o aborta explicándolo."""
+    parsed = AudioFormat.parse(value)
+    if parsed is None:
+        console.print(
+            f"[bold red]✗ Formato desconocido para {flag_name}: '{value}'[/bold red]\n"
+            f"  Valores válidos: [yellow]{', '.join(AudioFormat.choices())}[/yellow]\n"
+            f"  También se aceptan alias como: flac, mp3, 320k, m4a, aac, opus, ogg"
+        )
+        sys.exit(2)
+    return parsed
+
+
+def cli_entrypoint():
+    parser = argparse.ArgumentParser(
+        prog="monochrome",
+        description="Monochrome CLI: Buscador y descargador de música para Termux y Linux."
+    )
+    parser.add_argument("query", nargs="?", help="Término de búsqueda: título, artista o álbum")
+    parser.add_argument("-d", "--download", action="store_true", help="Descargar automáticamente el primer resultado")
+    parser.add_argument("-f", "--format", help=f"Formato de audio: {', '.join(AudioFormat.choices())}")
+    parser.add_argument("-o", "--output", help="Carpeta de destino de las descargas")
+    parser.add_argument("-a", "--album", action="store_true", help="Buscar y descargar álbum completo")
+    parser.add_argument("-w", "--overwrite", "--force", action="store_true", help="Sobrescribir si ya existe (por defecto omite duplicados)")
+    parser.add_argument("--lyrics", dest="lyrics", action="store_true", default=None, help="Descargar con letras sincronizadas (.lrc)")
+    parser.add_argument("--no-lyrics", dest="lyrics", action="store_false", help="Descargar sin letras sincronizadas")
+
+    # Persistent defaults commands
+    parser.add_argument("--set-default-format", help=f"Establecer formato predeterminado permanente ({', '.join(AudioFormat.choices())})")
+    parser.add_argument("--set-default-lyrics", choices=["true", "false"], help="Establecer si siempre descargar letras por defecto (true/false)")
+    parser.add_argument("--set-default-output", help="Establecer carpeta de descargas predeterminada permanente")
+    parser.add_argument("--set-default-country", help="Establecer el país del catálogo (código ISO de 2 letras: US, ES, MX...)")
+    parser.add_argument("--config", action="store_true", help="Abrir menú de configuración interactivo")
+
+    args = parser.parse_args()
+
+    # Handle persistent settings changes via CLI flags
+    if args.set_default_format:
+        config.default_format = resolve_format_argument(args.set_default_format, "--set-default-format")
+        console.print(f"[bold green]✔ Formato predeterminado guardado:[/bold green] {config.default_format.display_name}")
+        return
+
+    if args.set_default_lyrics:
+        val = args.set_default_lyrics.lower() == "true"
+        config.update({"embed_lyrics": val, "save_lrc_file": val})
+        console.print(f"[bold green]✔ Descarga de letras predeterminada guardada:[/bold green] {'Activada' if val else 'Desactivada'}")
+        return
+
+    if args.set_default_output:
+        config.download_directory = args.set_default_output
+        console.print(f"[bold green]✔ Directorio de descargas predeterminado guardado:[/bold green] {config.download_directory}")
+        return
+
+    if args.set_default_country:
+        country = args.set_default_country.strip().upper()
+        if len(country) != 2 or not country.isalpha():
+            console.print(f"[bold red]✗ País inválido: '{args.set_default_country}'. Usa un código ISO de 2 letras, por ejemplo ES.[/bold red]")
+            sys.exit(2)
+        config.set("country_code", country)
+        console.print(f"[bold green]✔ País del catálogo guardado:[/bold green] {config.country_code}")
+        return
+
+    if args.config:
+        configure_settings_interactive()
+        return
+
+    # Temporary run overrides
+    run_fmt = resolve_format_argument(args.format, "--format") if args.format else None
+    run_out = Path(args.output).expanduser() if args.output else None
+    run_lyrics = args.lyrics
+
+    if args.query:
+        query = args.query.strip()
+        console.print(f"[bold cyan]Buscando '{query}'...[/bold cyan]")
+        res = SearchEngine.search(query)
+
+        if not res.tracks and not res.albums:
+            console.print("[bold red]No se encontraron resultados.[/bold red]")
+            sys.exit(1)
+
+        if args.album:
+            if not res.albums:
+                console.print("[bold red]No se encontraron álbumes para esa búsqueda.[/bold red]")
+                sys.exit(1)
+            if not require_ffmpeg():
+                sys.exit(1)
+            album = res.albums[0]
+            console.print(f"[bold green]Descargando álbum: {album.title} - {album.artist}[/bold green]")
+            tracks = SearchEngine.get_album_tracks(album.source_id)
+            if not tracks:
+                console.print("[bold red]No se pudieron cargar las pistas del álbum.[/bold red]")
+                sys.exit(1)
+            download_batch_tracks(tracks, audio_format=run_fmt, output_dir=run_out, overwrite=args.overwrite, include_lyrics=run_lyrics)
+            return
+
+        if args.download and res.tracks:
+            if not require_ffmpeg():
+                sys.exit(1)
+            download_single_track(res.tracks[0], audio_format=run_fmt, output_dir=run_out, overwrite=args.overwrite, include_lyrics=run_lyrics)
+            return
+
+        # Interactive display for CLI query
+        display_tracks_table(res.tracks, title=f"Resultados para '{query}'")
+        if res.albums:
+            display_albums_table(res.albums, title=f"Álbumes para '{query}'")
+
+        selection = Prompt.ask("[bold yellow]Selecciona # para descargar (o 'all')[/bold yellow]", default="1")
+        action, payload = parse_selection(selection, len(res.tracks), len(res.albums))
+        if action == "error":
+            console.print(f"[red]{payload}[/red]")
+            sys.exit(1)
+        if action in ("quit", "search"):
+            return
+        if action == "album":
+            handle_album_selection(res.albums[payload])
+            return
+
+        if not require_ffmpeg():
+            sys.exit(1)
+        choice = ask_download_customization()
+        selected = [res.tracks[i] for i in payload]
+        overwrite = args.overwrite or choice.overwrite
+        if len(selected) == 1:
+            download_single_track(selected[0], audio_format=choice.audio_format, output_dir=run_out, overwrite=overwrite, include_lyrics=choice.lyrics)
+        else:
+            download_batch_tracks(selected, audio_format=choice.audio_format, output_dir=run_out, overwrite=overwrite, include_lyrics=choice.lyrics)
+        return
+
+    # Default: Start full interactive TUI
+    interactive_search_loop()
+
+
+if __name__ == "__main__":
+    cli_entrypoint()

--- a/cli/monochrome_cli/types.py
+++ b/cli/monochrome_cli/types.py
@@ -1,0 +1,162 @@
+"""
+Data types and models for Monochrome CLI.
+"""
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Optional, Dict, Any
+
+
+class AudioFormat(str, Enum):
+    """
+    Formato de salida. El audio se obtiene de YouTube (Opus/AAC de ~48-130 kbps
+    según los formatos accesibles), así que ninguna opción supera esa calidad:
+    FLAC solo evita una recompresión adicional a costa de multiplicar el tamaño,
+    y OPUS es el único que puede conservar el códec original sin pérdidas extra.
+    """
+
+    FLAC = "flac"
+    MP3_320 = "mp3_320"
+    MP3_256 = "mp3_256"
+    MP3_128 = "mp3_128"
+    M4A_256 = "m4a_256"
+    OPUS_160 = "opus_160"
+    OGG = "ogg"
+
+    @classmethod
+    def aliases(cls) -> Dict[str, "AudioFormat"]:
+        return {
+            "flac": cls.FLAC, "lossless": cls.FLAC, "hi_res": cls.FLAC, "hires": cls.FLAC,
+            "mp3_320": cls.MP3_320, "320": cls.MP3_320, "320k": cls.MP3_320,
+            "320kbps": cls.MP3_320, "mp3": cls.MP3_320,
+            "mp3_256": cls.MP3_256, "256": cls.MP3_256, "256k": cls.MP3_256, "256kbps": cls.MP3_256,
+            "mp3_128": cls.MP3_128, "128": cls.MP3_128, "128k": cls.MP3_128, "128kbps": cls.MP3_128,
+            "m4a": cls.M4A_256, "m4a_256": cls.M4A_256, "aac": cls.M4A_256,
+            "aac_256": cls.M4A_256, "m4a_hq": cls.M4A_256,
+            "opus": cls.OPUS_160, "opus_160": cls.OPUS_160,
+            "160k": cls.OPUS_160, "opus_hq": cls.OPUS_160,
+            "ogg": cls.OGG, "vorbis": cls.OGG,
+        }
+
+    @classmethod
+    def parse(cls, val: str) -> Optional["AudioFormat"]:
+        """Devuelve el formato, o None si el texto no corresponde a ninguno."""
+        key = str(val).strip().lower().replace("-", "_").replace(" ", "_")
+        return cls.aliases().get(key)
+
+    @classmethod
+    def from_string(cls, val: str) -> "AudioFormat":
+        """
+        Versión tolerante para valores ya guardados: si no se reconoce, cae al
+        formato por defecto. Para validar lo que escribe el usuario usa `parse`,
+        que distingue un valor inválido de uno válido.
+        """
+        return cls.parse(val) or cls.MP3_320
+
+    @classmethod
+    def choices(cls) -> List[str]:
+        """Valores canónicos aceptados por la línea de comandos."""
+        return [fmt.value for fmt in cls]
+
+    @property
+    def extension(self) -> str:
+        if self in (AudioFormat.MP3_320, AudioFormat.MP3_256, AudioFormat.MP3_128):
+            return "mp3"
+        if self == AudioFormat.FLAC:
+            return "flac"
+        if self == AudioFormat.M4A_256:
+            return "m4a"
+        if self == AudioFormat.OPUS_160:
+            return "opus"
+        if self == AudioFormat.OGG:
+            return "ogg"
+        return "mp3"
+
+    @property
+    def display_name(self) -> str:
+        names = {
+            AudioFormat.FLAC: "FLAC (sin recompresión; archivo grande)",
+            AudioFormat.MP3_320: "MP3 320 kbps (máxima compatibilidad)",
+            AudioFormat.MP3_256: "MP3 256 kbps (equilibrado)",
+            AudioFormat.MP3_128: "MP3 128 kbps (ahorro de espacio)",
+            AudioFormat.M4A_256: "M4A / AAC 256 kbps (Apple)",
+            AudioFormat.OPUS_160: "OPUS 160 kbps (recomendado: mismo códec que la fuente)",
+            AudioFormat.OGG: "OGG Vorbis 192 kbps",
+        }
+        return names.get(self, self.value)
+
+    @property
+    def ffmpeg_args(self) -> Dict[str, Any]:
+        if self == AudioFormat.FLAC:
+            return {"codec": "flac", "bitrate": None, "ext": "flac"}
+        if self == AudioFormat.MP3_320:
+            return {"codec": "libmp3lame", "bitrate": "320k", "ext": "mp3"}
+        if self == AudioFormat.MP3_256:
+            return {"codec": "libmp3lame", "bitrate": "256k", "ext": "mp3"}
+        if self == AudioFormat.MP3_128:
+            return {"codec": "libmp3lame", "bitrate": "128k", "ext": "mp3"}
+        if self == AudioFormat.M4A_256:
+            return {"codec": "aac", "bitrate": "256k", "ext": "m4a"}
+        if self == AudioFormat.OPUS_160:
+            return {"codec": "libopus", "bitrate": "160k", "ext": "opus"}
+        if self == AudioFormat.OGG:
+            return {"codec": "libvorbis", "bitrate": "192k", "ext": "ogg"}
+        return {"codec": "libmp3lame", "bitrate": "320k", "ext": "mp3"}
+
+
+@dataclass
+class LyricsData:
+    plain_lyrics: Optional[str] = None
+    synced_lyrics: Optional[str] = None
+    instrumental: bool = False
+    source: str = "lrclib"
+
+
+@dataclass
+class TrackMetadata:
+    title: str
+    artist: str
+    album: str
+    duration_seconds: int = 0
+    track_number: int = 1
+    total_tracks: int = 1
+    disc_number: int = 1
+    total_discs: int = 1
+    year: Optional[str] = None
+    release_date: Optional[str] = None
+    genre: Optional[str] = None
+    isrc: Optional[str] = None
+    album_artist: Optional[str] = None
+    cover_url: Optional[str] = None
+    explicit: bool = False
+    source: str = "tidal"
+    source_id: Optional[str] = None
+    stream_url: Optional[str] = None
+    lyrics: Optional[LyricsData] = None
+
+    @property
+    def duration_formatted(self) -> str:
+        if not self.duration_seconds:
+            return "--:--"
+        mins = self.duration_seconds // 60
+        secs = self.duration_seconds % 60
+        return f"{mins:02d}:{secs:02d}"
+
+
+@dataclass
+class AlbumMetadata:
+    title: str
+    artist: str
+    release_date: Optional[str] = None
+    year: Optional[str] = None
+    cover_url: Optional[str] = None
+    total_tracks: int = 0
+    tracks: List[TrackMetadata] = field(default_factory=list)
+    source: str = "tidal"
+    source_id: Optional[str] = None
+
+
+@dataclass
+class SearchResult:
+    tracks: List[TrackMetadata] = field(default_factory=list)
+    albums: List[AlbumMetadata] = field(default_factory=list)
+    query: str = ""

--- a/cli/monochrome_cli/ui/__init__.py
+++ b/cli/monochrome_cli/ui/__init__.py
@@ -1,0 +1,1 @@
+"""Componentes de interfaz (banner y tablas Rich)."""

--- a/cli/monochrome_cli/ui/banner.py
+++ b/cli/monochrome_cli/ui/banner.py
@@ -1,0 +1,36 @@
+"""
+Monochrome CLI ASCII Banner and Headers using Rich.
+"""
+from rich.console import Console
+from rich.panel import Panel
+from rich.text import Text
+from monochrome_cli.config import config
+from monochrome_cli.utils.platform import is_termux
+
+console = Console()
+
+BANNER_ART = r"""
+ ███▄ ▄███▓ ▒█████   ███▄    █  ▒█████   ▄████▄   ██░ ██  ██▀███   ▒█████   ███▄ ▄███▓▓█████
+▓██▒▀█▀ ██▒▒██▒  ██▒ ██ ▀█   █ ▒██▒  ██▒▒██▀ ▀█  ▓██░ ██▒▓██ ▒ ██▒▒██▒  ██▒▓██▒▀█▀ ██▒▓█   ▀
+▓██    ▓██░▒██░  ██▒▓██  ▀█ ██▒▒██░  ██▒▒▓█    ▄ ▒██▀▀██░▓██ ░▄█ ▒▒██░  ██▒▓██    ▓██░▒███  
+▒██    ▒██ ▒██   ██░▓██▒  ▐▌██▒▒██   ██░▒▓▓▄ ▄██▒░▓█ ░██ ▒██▀▀█▄  ▒██   ██░▒██    ▒██ ▒▓█  ▄
+▒██▒   ░██▒░ ████▓▒░▒██░   ▓██░░ ████▓▒░▒ ▓███▀ ░░▓█▒░██▓░██▓ ▒██▒░ ████▓▒░▒██▒   ░██▒░▒████▒
+░ ▒░   ░  ░░ ▒░▒░▒░ ░ ▒░   ▒ ▒ ░ ▒░▒░▒░ ░ ░▒ ▒  ░ ▒ ░░▒░▒░ ▒▓ ░▒▓░░ ▒░▒░▒░ ░ ▒░   ░  ░░░ ▒░ ░
+"""
+
+def print_banner():
+    platform_str = "[green]📱 Termux (Android)[/green]" if is_termux() else "[cyan]💻 Linux/Desktop[/cyan]"
+    fmt_str = f"[bold yellow]{config.default_format.display_name}[/bold yellow]"
+    dir_str = f"[dim]{config.download_directory}[/dim]"
+
+    text = Text(BANNER_ART, style="bold white")
+    subtitle = f"Versión 1.0.0 | {platform_str} | Formato: {fmt_str}\nDestino: {dir_str}"
+    
+    panel = Panel(
+        text,
+        subtitle=subtitle,
+        subtitle_align="center",
+        border_style="bright_blue",
+        padding=(0, 1)
+    )
+    console.print(panel)

--- a/cli/monochrome_cli/ui/tables.py
+++ b/cli/monochrome_cli/ui/tables.py
@@ -1,0 +1,124 @@
+"""
+Rich tables rendering for tracks, albums, formats, and settings.
+"""
+from typing import List
+from rich.console import Console
+from rich.table import Table
+from rich import box
+from monochrome_cli.types import TrackMetadata, AlbumMetadata, AudioFormat
+from monochrome_cli.config import config
+
+console = Console()
+
+
+def display_tracks_table(tracks: List[TrackMetadata], title: str = "Resultados de Canciones"):
+    table = Table(
+        title=f"[bold cyan]{title}[/bold cyan]",
+        box=box.ROUNDED,
+        header_style="bold magenta",
+        title_justify="left",
+        expand=True
+    )
+    table.add_column("#", justify="right", style="bold yellow", width=4)
+    table.add_column("Título", style="bold white", min_width=20)
+    table.add_column("Artista", style="cyan", min_width=18)
+    table.add_column("Álbum", style="dim white", min_width=18)
+    table.add_column("Duración", justify="center", style="green", width=10)
+    table.add_column("Año", justify="center", style="dim", width=6)
+    table.add_column("Metadatos", justify="center", style="bold bright_blue", width=10)
+
+    for i, t in enumerate(tracks, 1):
+        expl_badge = " [bold red][E][/bold red]" if t.explicit else ""
+        table.add_row(
+            str(i),
+            f"{t.title}{expl_badge}",
+            t.artist,
+            t.album or "—",
+            t.duration_formatted,
+            str(t.year or "—"),
+            "Tidal" if t.source == "tidal" else "Deezer"
+        )
+    console.print(table)
+
+
+def display_albums_table(albums: List[AlbumMetadata], title: str = "Resultados de Álbumes"):
+    if not albums:
+        return
+    table = Table(
+        title=f"[bold yellow]{title}[/bold yellow]",
+        box=box.ROUNDED,
+        header_style="bold magenta",
+        title_justify="left",
+        expand=True
+    )
+    table.add_column("Álbum #", justify="right", style="bold yellow", width=8)
+    table.add_column("Título del Álbum", style="bold white", min_width=25)
+    table.add_column("Artista", style="cyan", min_width=20)
+    table.add_column("Pistas", justify="center", style="green", width=8)
+    table.add_column("Año", justify="center", style="dim", width=6)
+
+    for i, a in enumerate(albums, 1):
+        table.add_row(
+            f"A{i}",
+            a.title,
+            a.artist,
+            str(a.total_tracks or "—"),
+            str(a.year or "—")
+        )
+    console.print(table)
+
+
+def display_formats_table():
+    console.print(
+        "[dim]El audio procede de YouTube (~48-130 kbps según disponibilidad). Ningún "
+        "formato de salida mejora esa calidad; solo cambian el tamaño y la compatibilidad.[/dim]"
+    )
+    table = Table(
+        title="[bold green]Seleccionar Formato de Audio[/bold green]",
+        box=box.ROUNDED,
+        header_style="bold magenta",
+        title_justify="left"
+    )
+    table.add_column("#", justify="right", style="bold yellow", width=4)
+    table.add_column("Formato", style="bold white", width=15)
+    table.add_column("Descripción", style="cyan", width=38)
+    table.add_column("Activo", justify="center", style="bold green", width=8)
+
+    formats = [
+        (1, AudioFormat.FLAC, "Sin recompresión, pero ocupa 4-5x más sin ganar calidad"),
+        (2, AudioFormat.MP3_320, "Máxima compatibilidad con cualquier reproductor"),
+        (3, AudioFormat.MP3_256, "Equilibrio entre tamaño y compatibilidad"),
+        (4, AudioFormat.M4A_256, "Formato Apple / AAC"),
+        (5, AudioFormat.OPUS_160, "Recomendado: mismo códec que la fuente, sin recodificar"),
+        (6, AudioFormat.MP3_128, "Ahorro máximo de espacio"),
+    ]
+
+    current_fmt = config.default_format
+    for num, fmt, desc in formats:
+        is_active = "✓" if fmt == current_fmt else ""
+        table.add_row(str(num), fmt.value.upper(), desc, is_active)
+
+    console.print(table)
+
+
+def display_settings_table():
+    table = Table(
+        title="[bold cyan]Configuración Actual de Monochrome CLI[/bold cyan]",
+        box=box.ROUNDED,
+        header_style="bold magenta",
+        title_justify="left"
+    )
+    table.add_column("Opción", style="bold white", width=25)
+    table.add_column("Valor Actual", style="yellow", min_width=35)
+    table.add_column("Descripción", style="dim", min_width=30)
+
+    table.add_row("Directorio de Descargas", str(config.download_directory), "Carpeta donde se guardará la música")
+    table.add_row("Formato por Defecto", config.default_format.display_name, "Calidad y extensión de audio")
+    table.add_row("Incrustar Portadas HD", "Sí" if config.embed_cover else "No", "Guarda la carátula en el archivo")
+    table.add_row("Resolución de Portada", f"{config.cover_resolution}x{config.cover_resolution} px", "Tamaño de imagen álbum")
+    table.add_row("Incrustar Letras", "Sí" if config.embed_lyrics else "No", "Etiqueta ID3 de letras sincronizadas")
+    table.add_row("Guardar archivo .lrc", "Sí" if config.save_lrc_file else "No", "Crea archivo de letras para reproductores")
+    table.add_row("Plantilla de Carpetas", config.folder_template, "Estructura de guardado")
+    table.add_row("País del Catálogo", config.country_code, "Región de Tidal: cambia qué ediciones aparecen")
+
+    console.print(table)

--- a/cli/monochrome_cli/utils/__init__.py
+++ b/cli/monochrome_cli/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utilidades de plataforma y plantillas de rutas."""

--- a/cli/monochrome_cli/utils/platform.py
+++ b/cli/monochrome_cli/utils/platform.py
@@ -1,0 +1,63 @@
+"""
+Platform detection and path utilities for Termux and Linux.
+"""
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+def is_termux() -> bool:
+    return (
+        'TERMUX_VERSION' in os.environ
+        or os.path.exists('/data/data/com.termux')
+        or 'com.termux' in os.environ.get('PREFIX', '')
+    )
+
+
+def is_android() -> bool:
+    return is_termux() or os.path.exists('/sdcard')
+
+
+def get_default_music_dir() -> Path:
+    # 1. Check Termux shared storage
+    termux_shared = Path(os.path.expanduser('~/storage/shared/Music'))
+    if termux_shared.exists() and os.access(termux_shared, os.W_OK):
+        return termux_shared
+
+    # 2. Check direct /sdcard/Music
+    sdcard_music = Path('/sdcard/Music')
+    if sdcard_music.exists() and os.access(sdcard_music, os.W_OK):
+        return sdcard_music
+
+    # 3. Standard Linux / macOS ~/Music
+    user_music = Path(os.path.expanduser('~/Music/Monochrome'))
+    return user_music
+
+
+def get_config_dir() -> Path:
+    """
+    Devuelve la ruta de configuración sin crearla: quien escriba el archivo se
+    encarga del mkdir, para que arrancar la CLI no toque el disco.
+    """
+    if sys.platform == 'win32' and not is_termux():
+        appdata = os.environ.get('APPDATA', os.path.expanduser('~'))
+        return Path(appdata) / 'monochrome-cli'
+    return Path(os.path.expanduser('~/.config/monochrome-cli'))
+
+
+def find_ffmpeg() -> Optional[str]:
+    """Ruta del ejecutable de FFmpeg, o None si no está instalado."""
+    return shutil.which('ffmpeg') or shutil.which('ffmpeg.exe')
+
+
+def ffmpeg_install_hint() -> str:
+    """Instrucción de instalación de FFmpeg adaptada a la plataforma actual."""
+    if is_termux():
+        return "pkg install ffmpeg"
+    if sys.platform == 'darwin':
+        return "brew install ffmpeg"
+    if sys.platform == 'win32':
+        return "winget install Gyan.FFmpeg"
+    return "sudo apt install ffmpeg   (o: sudo pacman -S ffmpeg / sudo dnf install ffmpeg)"

--- a/cli/monochrome_cli/utils/template.py
+++ b/cli/monochrome_cli/utils/template.py
@@ -1,0 +1,73 @@
+"""
+Filename and folder template formatting utilities.
+"""
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from monochrome_cli.types import TrackMetadata, AudioFormat
+
+
+def sanitize_filename(name: str) -> str:
+    """Removes invalid filesystem characters."""
+    if not name:
+        return "Unknown"
+    sanitized = re.sub(r'[\\/*?:"<>|]', '_', name)
+    sanitized = re.sub(r'\s+', ' ', sanitized).strip()
+    return sanitized or "Unknown"
+
+
+def format_track_path(
+    track: "TrackMetadata",
+    output_dir: Path,
+    audio_format: "AudioFormat",
+    folder_template: str = "{album_artist}/{album}/{track_number:02d} - {title}",
+    create_dirs: bool = False
+) -> Path:
+    """
+    Builds the full destination path based on template and metadata.
+
+    Por defecto solo calcula la ruta. Crear las carpetas es responsabilidad de
+    quien va a escribir el archivo: así consultar el destino de una pista que se
+    va a omitir por duplicada no deja directorios vacíos por el disco.
+    """
+    artist = sanitize_filename(track.artist or "Unknown Artist")
+    album_artist = sanitize_filename(track.album_artist or track.artist or "Unknown Artist")
+    album = sanitize_filename(track.album or "Unknown Album")
+    title = sanitize_filename(track.title or "Unknown Title")
+    year = sanitize_filename(track.year or "")
+    genre = sanitize_filename(track.genre or "")
+    track_number = track.track_number or 1
+    disc_number = track.disc_number or 1
+    ext = audio_format.extension
+
+    context = {
+        "artist": artist,
+        "album_artist": album_artist,
+        "album": album,
+        "title": title,
+        "year": year,
+        "genre": genre,
+        "track_number": track_number,
+        "disc_number": disc_number,
+    }
+
+    try:
+        relative_path_str = folder_template.format(**context)
+    except Exception:
+        relative_path_str = f"{artist} - {title}"
+
+    parts = [sanitize_filename(p) for p in relative_path_str.replace("\\", "/").split("/") if p.strip()]
+    if not parts:
+        parts = [f"{artist} - {title}"]
+
+    file_name = f"{parts[-1]}.{ext}"
+    if len(parts) > 1:
+        folder_path = output_dir.joinpath(*parts[:-1])
+    else:
+        folder_path = output_dir
+
+    if create_dirs:
+        folder_path.mkdir(parents=True, exist_ok=True)
+    return folder_path / file_name

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -1,0 +1,22 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="monochrome-cli",
+    version="1.0.0",
+    description="Monochrome Music CLI & Downloader for Termux and Linux",
+    author="Monochrome Music Community",
+    packages=find_packages(),
+    python_requires=">=3.8",
+    install_requires=[
+        "yt-dlp>=2024.0.0",
+        "mutagen>=1.47.0",
+        "rich>=13.0.0",
+        "requests>=2.28.0",
+    ],
+    entry_points={
+        "console_scripts": [
+            "mono = monochrome_cli.main:cli_entrypoint",
+            "monochrome = monochrome_cli.main:cli_entrypoint",
+        ],
+    },
+)

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -1,0 +1,37 @@
+"""
+Configuración de pytest para esta carpeta.
+
+La mayoría de los archivos de aquí son pruebas en vivo: buscan en Tidal y
+descargan audio real de YouTube. Recolectarlas sin querer (por ejemplo con un
+`pytest` a secas en CI) dispara descargas de varios minutos, así que solo se
+ejecutan cuando se piden explícitamente:
+
+    MONOCHROME_LIVE_TESTS=1 pytest tests/
+
+Sin esa variable se ejecutan únicamente las pruebas unitarias, que no tocan red.
+Todos los archivos siguen siendo ejecutables a mano: `python3 tests/test_search.py`.
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+LIVE_TEST_FILES = {
+    "test_search.py",
+    "test_lyrics.py",
+    "test_tagger.py",
+    "test_downloader.py",
+    "test_full_pipeline.py",
+    "test_artist_downloads.py",
+}
+
+
+def pytest_collection_modifyitems(config, items):
+    if os.environ.get("MONOCHROME_LIVE_TESTS") == "1":
+        return
+    skip_live = pytest.mark.skip(
+        reason="prueba en vivo (red/descargas); ejecuta con MONOCHROME_LIVE_TESTS=1"
+    )
+    for item in items:
+        if Path(str(item.fspath)).name in LIVE_TEST_FILES:
+            item.add_marker(skip_live)

--- a/cli/tests/test_artist_downloads.py
+++ b/cli/tests/test_artist_downloads.py
@@ -1,0 +1,160 @@
+"""
+Live download and verification test for Tainy and David Guetta songs.
+"""
+import sys
+import tempfile
+from pathlib import Path
+
+# Add cli to sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from mutagen.id3 import ID3
+from mutagen.flac import FLAC
+from mutagen.mp4 import MP4
+
+from monochrome_cli.core.search import SearchEngine
+from monochrome_cli.core.downloader import Downloader
+from monochrome_cli.types import AudioFormat
+
+
+def inspect_mp3(file_path):
+    audio = ID3(file_path)
+    title = audio.get("TIT2")
+    artist = audio.get("TPE1")
+    album = audio.get("TALB")
+    print("   [ID3v2] Titulo: {}".format(title))
+    print("   [ID3v2] Artista: {}".format(artist))
+    print("   [ID3v2] Album: {}".format(album))
+
+    apic = [v for k, v in audio.items() if k.startswith("APIC")]
+    if apic:
+        print("   [Portada HD] Incrustada: {} bytes ({})".format(len(apic[0].data), apic[0].mime))
+    uslt = [v for k, v in audio.items() if k.startswith("USLT")]
+    if uslt:
+        snippet = uslt[0].text[:80].replace("\n", " ")
+        print('   [Letras ID3] Incrustadas: "{}..."'.format(snippet))
+
+
+def inspect_flac(file_path):
+    audio = FLAC(file_path)
+    print("   [FLAC] Titulo: {}".format(audio.get("TITLE", [None])[0]))
+    print("   [FLAC] Artista: {}".format(audio.get("ARTIST", [None])[0]))
+    print("   [FLAC] Album: {}".format(audio.get("ALBUM", [None])[0]))
+    if audio.pictures:
+        pic = audio.pictures[0]
+        print("   [Portada HD] Incrustada: {} bytes ({})".format(len(pic.data), pic.mime))
+    if "LYRICS" in audio:
+        snippet = audio["LYRICS"][0][:80].replace("\n", " ")
+        print('   [Letras FLAC] Incrustadas: "{}..."'.format(snippet))
+
+
+def inspect_m4a(file_path):
+    audio = MP4(file_path)
+    print("   [MP4] Titulo: {}".format(audio.get("\xa9nam", [None])[0]))
+    print("   [MP4] Artista: {}".format(audio.get("\xa9ART", [None])[0]))
+    print("   [MP4] Album: {}".format(audio.get("\xa9alb", [None])[0]))
+    if "covr" in audio:
+        print("   [Portada HD] Incrustada: {} bytes".format(len(audio["covr"][0])))
+    if "\xa9lyr" in audio:
+        snippet = audio["\xa9lyr"][0][:80].replace("\n", " ")
+        print('   [Letras MP4] Incrustadas: "{}..."'.format(snippet))
+
+
+INSPECTORS = {
+    ".mp3": inspect_mp3,
+    ".flac": inspect_flac,
+    ".m4a": inspect_m4a,
+}
+
+
+def run_artist_tests(output_base=None):
+    temp_holder = None
+    if output_base is None:
+        temp_holder = tempfile.TemporaryDirectory()
+        output_base = Path(temp_holder.name)
+    else:
+        output_base = Path(output_base)
+        output_base.mkdir(parents=True, exist_ok=True)
+
+    test_cases = [
+        {
+            "query": "Tainy Bad Bunny MOJABI GHOST",
+            "format": AudioFormat.MP3_320,
+            "artist_label": "Tainy / Bad Bunny",
+            "expected_ext": ".mp3",
+        },
+        {
+            "query": "David Guetta Sia Titanium",
+            "format": AudioFormat.FLAC,
+            "artist_label": "David Guetta (Titanium)",
+            "expected_ext": ".flac",
+        },
+        {
+            "query": "David Guetta Bebe Rexha I'm Good Blue",
+            "format": AudioFormat.M4A_256,
+            "artist_label": "David Guetta (I'm Good)",
+            "expected_ext": ".m4a",
+        },
+    ]
+
+    downloaded_files = []
+
+    try:
+        for case in test_cases:
+            query = case["query"]
+            fmt = case["format"]
+            expected_ext = case["expected_ext"]
+            print("\n==================================================")
+            print("Buscando {} para prueba [{}]...".format(query, fmt.value.upper()))
+            print("==================================================")
+
+            res = SearchEngine.search(query, limit=1)
+            assert len(res.tracks) > 0, "No tracks found for {}".format(query)
+            track = res.tracks[0]
+
+            print("OK Pista encontrada: {} - {} (Album: {})".format(track.artist, track.title, track.album))
+            print("  Portada URL: {}".format(track.cover_url))
+
+            print("Descargando en {}...".format(fmt.display_name))
+            saved_file, is_new = Downloader.download_track(
+                track, audio_format=fmt, output_dir=output_base
+            )
+            assert saved_file is not None and saved_file.exists(), \
+                "Failed to download {}".format(track.title)
+            assert saved_file.suffix == expected_ext, \
+                "Expected {}, got {}".format(expected_ext, saved_file.suffix)
+
+            size_mb = saved_file.stat().st_size / (1024 * 1024)
+            print("OK Archivo generado: {} ({:.2f} MB, nuevo={})".format(saved_file, size_mb, is_new))
+            downloaded_files.append((saved_file, track, fmt))
+
+        print("\n==================================================")
+        print("INSPECCIONANDO METADATOS, PORTADAS Y LETRAS")
+        print("==================================================")
+
+        for file_path, track, fmt in downloaded_files:
+            print("\nArchivo: {}".format(file_path.name))
+            print("   Ruta completa: {}".format(file_path))
+            print("   Tamano: {:.2f} MB".format(file_path.stat().st_size / (1024 * 1024)))
+
+            inspector = INSPECTORS.get(file_path.suffix.lower())
+            if inspector:
+                inspector(file_path)
+
+            # Comprobar archivo companero .lrc
+            lrc_file = file_path.with_suffix(".lrc")
+            if lrc_file.exists():
+                print("   [Letras .lrc] Archivo generado: {} ({} bytes)".format(
+                    lrc_file.name, lrc_file.stat().st_size))
+                with open(lrc_file, "r", encoding="utf-8") as f:
+                    first_lines = [f.readline().strip() for _ in range(2)]
+                print("   [Letras .lrc Muestra] {}".format(" | ".join(first_lines)))
+
+        print("\n>>> TODAS LAS PRUEBAS DE DESCARGA E INSPECCION FINALIZARON CON EXITO <<<")
+    finally:
+        if temp_holder is not None:
+            temp_holder.cleanup()
+
+
+if __name__ == "__main__":
+    run_artist_tests(sys.argv[1] if len(sys.argv) > 1 else None)

--- a/cli/tests/test_downloader.py
+++ b/cli/tests/test_downloader.py
@@ -1,0 +1,98 @@
+"""
+End-to-end live download tests for FLAC, MP3 320k, M4A, and OPUS.
+"""
+import sys
+import tempfile
+from pathlib import Path
+
+# Add cli to sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from mutagen.id3 import ID3
+from mutagen.flac import FLAC
+from monochrome_cli.core.downloader import Downloader
+from monochrome_cli.types import TrackMetadata, AudioFormat
+
+
+def test_live_download_mp3():
+    print("Testing live download: MP3 320kbps + HD Cover + Lyrics...")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_dir = Path(tmpdir)
+        
+        # Test track
+        track = TrackMetadata(
+            title="Get Lucky",
+            artist="Daft Punk",
+            album="Random Access Memories",
+            year="2013",
+            track_number=8,
+            total_tracks=13,
+            cover_url="https://resources.tidal.com/images/b66a5c40/c34d/4507/a0dc/5f98e46fdd20/1280x1280.jpg",
+            duration_seconds=369
+        )
+
+        def on_progress(pct, msg):
+            pass
+
+        saved_path, _ = Downloader.download_track(
+            track,
+            audio_format=AudioFormat.MP3_320,
+            output_dir=output_dir,
+            progress_callback=on_progress
+        )
+
+        assert saved_path is not None and saved_path.exists(), "MP3 download failed"
+        assert saved_path.suffix == ".mp3", f"Expected .mp3, got {saved_path.suffix}"
+        assert saved_path.stat().st_size > 500_000, f"File size too small: {saved_path.stat().st_size} bytes"
+        print(f"  ✔ File downloaded: {saved_path.name} ({saved_path.stat().st_size / (1024*1024):.2f} MB)")
+
+        # Verify ID3 and cover
+        id3 = ID3(saved_path)
+        assert id3.get("TIT2").text[0] == "Get Lucky"
+        assert id3.get("TPE1").text[0] == "Daft Punk"
+        assert any(k.startswith("APIC") for k in id3.keys()), "APIC cover missing"
+        print("  ✔ ID3 tags & Cover art verified inside MP3!")
+
+        # Verify .lrc file
+        lrc_path = saved_path.with_suffix(".lrc")
+        if lrc_path.exists():
+            print(f"  ✔ Synced .lrc lyrics file created: {lrc_path.name} ({lrc_path.stat().st_size} bytes)")
+
+
+def test_live_download_flac():
+    print("Testing live download: FLAC Lossless...")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_dir = Path(tmpdir)
+        
+        track = TrackMetadata(
+            title="Around the World",
+            artist="Daft Punk",
+            album="Homework",
+            year="1997",
+            track_number=7,
+            cover_url="https://resources.tidal.com/images/b66a5c40/c34d/4507/a0dc/5f98e46fdd20/1280x1280.jpg",
+            duration_seconds=429
+        )
+
+        saved_path, _ = Downloader.download_track(
+            track,
+            audio_format=AudioFormat.FLAC,
+            output_dir=output_dir
+        )
+
+        assert saved_path is not None and saved_path.exists(), "FLAC download failed"
+        assert saved_path.suffix == ".flac", f"Expected .flac, got {saved_path.suffix}"
+        assert saved_path.stat().st_size > 1_000_000, f"FLAC file size too small: {saved_path.stat().st_size} bytes"
+        print(f"  ✔ File downloaded: {saved_path.name} ({saved_path.stat().st_size / (1024*1024):.2f} MB)")
+
+        # Verify FLAC tags
+        flac_audio = FLAC(saved_path)
+        assert flac_audio["TITLE"][0] == "Around the World"
+        assert len(flac_audio.pictures) > 0, "FLAC Picture block missing"
+        print("  ✔ FLAC Vorbis comments & Picture block verified!")
+
+
+if __name__ == "__main__":
+    test_live_download_mp3()
+    test_live_download_flac()
+    print("\n[ALL LIVE DOWNLOAD TESTS PASSED SUCCESSFULLY!]")

--- a/cli/tests/test_full_pipeline.py
+++ b/cli/tests/test_full_pipeline.py
@@ -1,0 +1,73 @@
+"""
+Full integration test covering Search -> Selection -> Format Conversion -> Tagging -> Folder Structure.
+"""
+import sys
+import tempfile
+from pathlib import Path
+
+# Add cli to sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from mutagen.mp4 import MP4
+from mutagen.oggopus import OggOpus
+
+from monochrome_cli.core.search import SearchEngine
+from monochrome_cli.core.downloader import Downloader
+from monochrome_cli.types import AudioFormat
+
+
+def test_search_and_download_m4a():
+    print("1. Testing Search + M4A (AAC 256k) Download...")
+    res = SearchEngine.search("The Weeknd Blinding Lights", limit=1)
+    assert len(res.tracks) > 0, "Track search returned no results"
+    track = res.tracks[0]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_dir = Path(tmpdir)
+        saved_path, _ = Downloader.download_track(track, audio_format=AudioFormat.M4A_256, output_dir=out_dir)
+        assert saved_path is not None and saved_path.exists(), "M4A download failed"
+        assert saved_path.suffix == ".m4a"
+        print(f"  ✔ M4A created: {saved_path.name} ({saved_path.stat().st_size / (1024*1024):.2f} MB)")
+
+        mp4 = MP4(saved_path)
+        assert "©nam" in mp4
+        assert "covr" in mp4
+        print("  ✔ M4A atom tags and HD cover verified!")
+
+
+def test_search_and_download_opus():
+    print("2. Testing Search + OPUS (160k) Download...")
+    res = SearchEngine.search("Dua Lipa Levitating", limit=1)
+    assert len(res.tracks) > 0, "Track search returned no results"
+    track = res.tracks[0]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_dir = Path(tmpdir)
+        saved_path, _ = Downloader.download_track(track, audio_format=AudioFormat.OPUS_160, output_dir=out_dir)
+        assert saved_path is not None and saved_path.exists(), "OPUS download failed"
+        assert saved_path.suffix == ".opus"
+        print(f"  ✔ OPUS created: {saved_path.name} ({saved_path.stat().st_size / (1024*1024):.2f} MB)")
+
+        opus = OggOpus(saved_path)
+        assert "title" in opus
+        assert "artist" in opus
+        print("  ✔ OPUS metadata comments verified!")
+
+
+def test_album_batch_download_simulation():
+    print("3. Testing Album Batch Structure Retrieval...")
+    albums = SearchEngine.search_tidal_albums("Discovery Daft Punk", limit=1)
+    assert len(albums) > 0, "Album search failed"
+    album = albums[0]
+    tracks = SearchEngine.get_album_tracks(album.source_id)
+    assert len(tracks) >= 5, "Expected tracks for album"
+    print(f"  ✔ Retrieved album: '{album.title}' with {len(tracks)} tracks.")
+    for i, t in enumerate(tracks[:4], 1):
+        print(f"    {i}. {t.track_number:02d} - {t.title} ({t.duration_formatted})")
+
+
+if __name__ == "__main__":
+    test_search_and_download_m4a()
+    test_search_and_download_opus()
+    test_album_batch_download_simulation()
+    print("\n[ALL FULL PIPELINE INTEGRATION TESTS PASSED!]")

--- a/cli/tests/test_lyrics.py
+++ b/cli/tests/test_lyrics.py
@@ -1,0 +1,45 @@
+"""
+Tests for LyricsManager and .lrc file generation.
+"""
+import sys
+import tempfile
+from pathlib import Path
+
+# Add cli to sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from monochrome_cli.core.lyrics import LyricsManager
+from monochrome_cli.types import TrackMetadata
+
+
+def test_lyrics_fetching():
+    print("Testing LRCLIB lyrics fetching...")
+    track = TrackMetadata(
+        title="Bohemian Rhapsody",
+        artist="Queen",
+        album="A Night At The Opera",
+        duration_seconds=354
+    )
+
+    lyrics = LyricsManager.fetch_lyrics(track)
+    assert lyrics is not None, "Failed to fetch lyrics for Bohemian Rhapsody"
+    print(f"  ✔ Lyrics fetched from source: {lyrics.source}")
+    assert lyrics.synced_lyrics or lyrics.plain_lyrics, "No lyrics text found"
+
+    if lyrics.synced_lyrics:
+        print("  ✔ Synced lyrics found! Sample line:")
+        first_lines = lyrics.synced_lyrics.strip().splitlines()[:3]
+        for line in first_lines:
+            print(f"    {line}")
+        assert "[" in lyrics.synced_lyrics and "]" in lyrics.synced_lyrics, "Synced lyrics missing timestamps"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dummy_audio = Path(tmpdir) / "Queen - Bohemian Rhapsody.mp3"
+        dummy_audio.touch()
+        lrc_file = LyricsManager.save_lrc_file(lyrics, dummy_audio)
+        assert lrc_file is not None and lrc_file.exists(), "LRC file was not created"
+        print(f"  ✔ .lrc file written successfully: {lrc_file.name} ({lrc_file.stat().st_size} bytes)")
+
+if __name__ == "__main__":
+    test_lyrics_fetching()
+    print("\n[ALL LYRICS TESTS PASSED SUCCESSFULLY!]")

--- a/cli/tests/test_search.py
+++ b/cli/tests/test_search.py
@@ -1,0 +1,53 @@
+"""
+Tests for SearchEngine (Tidal & Deezer).
+"""
+import sys
+from pathlib import Path
+
+# Add cli to sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from monochrome_cli.core.search import SearchEngine
+
+
+def test_tidal_search():
+    print("Testing Tidal search...")
+    res = SearchEngine.search_tidal_tracks("Daft Punk Get Lucky", limit=3)
+    assert len(res) > 0, "Tidal search returned no tracks"
+    first = res[0]
+    print(f"  ✔ Found: {first.title} by {first.artist} (Album: {first.album}, Duration: {first.duration_formatted})")
+    assert first.title, "Track title is empty"
+    assert first.artist, "Artist is empty"
+    assert first.cover_url, "Cover URL is empty"
+    print(f"  ✔ Cover URL: {first.cover_url}")
+
+
+def test_deezer_search():
+    print("Testing Deezer fallback search...")
+    res = SearchEngine.search_deezer_tracks("Queen Bohemian Rhapsody", limit=3)
+    assert len(res) > 0, "Deezer search returned no tracks"
+    first = res[0]
+    print(f"  ✔ Found: {first.title} by {first.artist} (Album: {first.album})")
+    assert first.title, "Track title is empty"
+    assert first.cover_url, "Cover URL is empty"
+
+
+def test_album_search_and_tracks():
+    print("Testing Album search and track retrieval...")
+    res = SearchEngine.search_tidal_albums("Random Access Memories", limit=2)
+    assert len(res) > 0, "Album search returned no albums"
+    first_album = res[0]
+    print(f"  ✔ Found Album: {first_album.title} by {first_album.artist} (ID: {first_album.source_id})")
+
+    tracks = SearchEngine.get_album_tracks(first_album.source_id)
+    assert len(tracks) > 0, "Failed to retrieve tracks for album"
+    print(f"  ✔ Retrieved {len(tracks)} tracks from album:")
+    for t in tracks[:3]:
+        print(f"    - [{t.track_number:02d}] {t.title} ({t.duration_formatted})")
+
+
+if __name__ == "__main__":
+    test_tidal_search()
+    test_deezer_search()
+    test_album_search_and_tracks()
+    print("\n[ALL SEARCH TESTS PASSED SUCCESSFULLY!]")

--- a/cli/tests/test_tagger.py
+++ b/cli/tests/test_tagger.py
@@ -1,0 +1,189 @@
+"""
+Tests for MetadataTagger and cover art embedding across MP3, FLAC, M4A, OPUS.
+"""
+import base64
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Add cli to sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from mutagen.flac import FLAC, Picture
+from mutagen.id3 import ID3
+from mutagen.mp4 import MP4
+from mutagen.oggopus import OggOpus
+
+from monochrome_cli.core.tagger import MetadataTagger
+from monochrome_cli.types import AudioFormat, LyricsData, TrackMetadata
+
+
+def create_dummy_audio(path: Path, codec: str = "libmp3lame", duration: int = 1):
+    # Generate 1 sec of silent audio using ffmpeg
+    subprocess.run([
+        "ffmpeg", "-y", "-f", "lavfi", "-i", "anullsrc=r=44100:cl=stereo",
+        "-t", str(duration), "-acodec", codec, str(path)
+    ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
+
+
+def test_cover_fetching():
+    print("Testing cover art fetching...")
+    # Tidal cover image
+    test_cover_url = "https://resources.tidal.com/images/b66a5c40/c34d/4507/a0dc/5f98e46fdd20/1280x1280.jpg"
+    data = MetadataTagger.fetch_cover_bytes(test_cover_url)
+    assert data is not None, "Failed to download cover bytes"
+    assert len(data) > 5000, f"Cover image too small: {len(data)} bytes"
+    print(f"  ✔ Cover fetched successfully ({len(data)} bytes, JPEG/PNG)")
+
+
+def test_mp3_tagging():
+    print("Testing MP3 ID3v2.4 tagging & cover art...")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file_path = Path(tmpdir) / "test.mp3"
+        create_dummy_audio(file_path, codec="libmp3lame")
+
+        track = TrackMetadata(
+            title="Get Lucky",
+            artist="Daft Punk",
+            album="Random Access Memories",
+            album_artist="Daft Punk",
+            track_number=8,
+            total_tracks=13,
+            disc_number=1,
+            total_discs=1,
+            year="2013",
+            genre="Disco",
+            isrc="USQX91300105",
+            cover_url="https://resources.tidal.com/images/b66a5c40/c34d/4507/a0dc/5f98e46fdd20/1280x1280.jpg",
+            lyrics=LyricsData(plain_lyrics="Like the legend of the phoenix...", synced_lyrics="[00:05.00] Like the legend...")
+        )
+
+        ok = MetadataTagger.apply_metadata(file_path, track, AudioFormat.MP3_320, embed_cover=True, embed_lyrics=True)
+        assert ok, "Metadata application failed"
+
+        # Verify with Mutagen ID3
+        audio = ID3(file_path)
+        assert audio.get("TIT2").text[0] == "Get Lucky"
+        assert audio.get("TPE1").text[0] == "Daft Punk"
+        assert audio.get("TALB").text[0] == "Random Access Memories"
+        assert audio.get("TRCK").text[0] == "8/13"
+        assert str(audio.get("TDRC").text[0]) == "2013"
+        assert audio.get("TSRC").text[0] == "USQX91300105"
+        assert "APIC:Cover" in audio or any(k.startswith("APIC") for k in audio.keys()), "APIC cover not found"
+        assert "USLT:Lyrics:eng" in audio or any(k.startswith("USLT") for k in audio.keys()), "USLT lyrics not found"
+        print("  ✔ MP3 tags (TIT2, TPE1, TALB, TRCK, TDRC, TSRC, APIC, USLT) verified!")
+
+
+def test_flac_tagging():
+    print("Testing FLAC Vorbis comment tagging & Picture block...")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file_path = Path(tmpdir) / "test.flac"
+        create_dummy_audio(file_path, codec="flac")
+
+        track = TrackMetadata(
+            title="Get Lucky",
+            artist="Daft Punk",
+            album="Random Access Memories",
+            track_number=8,
+            year="2013",
+            cover_url="https://resources.tidal.com/images/b66a5c40/c34d/4507/a0dc/5f98e46fdd20/1280x1280.jpg"
+        )
+
+        ok = MetadataTagger.apply_metadata(file_path, track, AudioFormat.FLAC, embed_cover=True)
+        assert ok, "FLAC tagging failed"
+
+        audio = FLAC(file_path)
+        assert audio["TITLE"][0] == "Get Lucky"
+        assert audio["ARTIST"][0] == "Daft Punk"
+        assert audio["ALBUM"][0] == "Random Access Memories"
+        assert audio["TRACKNUMBER"][0] == "8"
+        assert len(audio.pictures) > 0, "FLAC pictures empty"
+        print(f"  ✔ FLAC tags & Picture block ({audio.pictures[0].mime}) verified!")
+
+
+def test_m4a_tagging():
+    print("Testing M4A MP4 atoms & cover art...")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file_path = Path(tmpdir) / "test.m4a"
+        create_dummy_audio(file_path, codec="aac")
+
+        track = TrackMetadata(
+            title="Get Lucky",
+            artist="Daft Punk",
+            album="Random Access Memories",
+            track_number=8,
+            total_tracks=13,
+            year="2013",
+            cover_url="https://resources.tidal.com/images/b66a5c40/c34d/4507/a0dc/5f98e46fdd20/1280x1280.jpg"
+        )
+
+        ok = MetadataTagger.apply_metadata(file_path, track, AudioFormat.M4A_256, embed_cover=True)
+        assert ok, "M4A tagging failed"
+
+        audio = MP4(file_path)
+        assert audio["©nam"][0] == "Get Lucky"
+        assert audio["©ART"][0] == "Daft Punk"
+        assert audio["©alb"][0] == "Random Access Memories"
+        assert audio["trkn"][0] == (8, 13)
+        assert "covr" in audio and len(audio["covr"]) > 0, "covr atom not found"
+        print("  ✔ M4A MP4 atoms (©nam, ©ART, ©alb, trkn, covr) verified!")
+
+
+def test_opus_tagging():
+    print("Testing OPUS Vorbis comments & METADATA_BLOCK_PICTURE cover...")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file_path = Path(tmpdir) / "test.opus"
+        create_dummy_audio(file_path, codec="libopus")
+
+        track = TrackMetadata(
+            title="Get Lucky",
+            artist="Daft Punk",
+            album="Random Access Memories",
+            album_artist="Daft Punk",
+            track_number=8,
+            total_tracks=13,
+            year="2013",
+            cover_url="https://resources.tidal.com/images/b66a5c40/c34d/4507/a0dc/5f98e46fdd20/1280x1280.jpg",
+            lyrics=LyricsData(synced_lyrics="[00:05.00] Like the legend..."),
+        )
+
+        ok = MetadataTagger.apply_metadata(file_path, track, AudioFormat.OPUS_160,
+                                           embed_cover=True, embed_lyrics=True)
+        assert ok, "OPUS tagging failed"
+
+        audio = OggOpus(file_path)
+        assert audio["title"][0] == "Get Lucky"
+        assert audio["artist"][0] == "Daft Punk"
+        assert audio["albumartist"][0] == "Daft Punk"
+        assert audio["tracknumber"][0] == "8"
+        assert "lyrics" in audio, "OPUS lyrics missing"
+
+        assert "metadata_block_picture" in audio, "OPUS cover missing"
+        pic = Picture(base64.b64decode(audio["metadata_block_picture"][0]))
+        assert pic.type == 3, "Cover is not marked as Front Cover"
+        assert len(pic.data) > 5000, "Cover data too small"
+        assert pic.width > 0 and pic.height > 0, "Cover dimensions not written"
+        print("  OK OPUS comments & cover verified ({}x{}, {}, {} bytes)!".format(
+            pic.width, pic.height, pic.mime, len(pic.data)))
+
+
+def test_unknown_extension_is_reported():
+    print("Testing that an unsupported container is not reported as success...")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file_path = Path(tmpdir) / "test.wma"
+        file_path.write_bytes(b"not really audio")
+        track = TrackMetadata(title="X", artist="Y", album="Z")
+        ok = MetadataTagger.apply_metadata(file_path, track, AudioFormat.MP3_320)
+        assert ok is False, "Unknown extension must not report success"
+        print("  OK unsupported extension correctly returns False!")
+
+
+if __name__ == "__main__":
+    test_cover_fetching()
+    test_mp3_tagging()
+    test_flac_tagging()
+    test_m4a_tagging()
+    test_opus_tagging()
+    test_unknown_extension_is_reported()
+    print("\n[ALL TAGGER AND METADATA TESTS PASSED SUCCESSFULLY!]")

--- a/cli/tests/test_units.py
+++ b/cli/tests/test_units.py
@@ -1,0 +1,208 @@
+"""
+Pruebas unitarias sin red ni descargas: plantillas, formatos, configuracion y
+el parseo de la seleccion del menu interactivo.
+"""
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from monochrome_cli.config import Config, DEFAULT_TIDAL_CLIENT_ID, DEFAULT_TIDAL_CLIENT_SECRET
+from monochrome_cli.core.tagger import image_dimensions, is_png
+from monochrome_cli.main import parse_selection
+from monochrome_cli.types import AudioFormat, TrackMetadata
+from monochrome_cli.utils.template import format_track_path, sanitize_filename
+
+
+def test_sanitize_filename():
+    print("Testing sanitize_filename...")
+    assert sanitize_filename('AC/DC') == 'AC_DC'
+    assert sanitize_filename('a:b*c?d"e<f>g|h') == 'a_b_c_d_e_f_g_h'
+    assert sanitize_filename('  espacios   dobles  ') == 'espacios dobles'
+    assert sanitize_filename('') == 'Unknown'
+    assert sanitize_filename('///') == '___'  # separadores -> guiones bajos, no se pierde el nombre
+    assert sanitize_filename(None) == 'Unknown'
+    print("  OK nombres saneados correctamente")
+
+
+def test_format_track_path():
+    print("Testing format_track_path...")
+    track = TrackMetadata(
+        title="Get Lucky", artist="Daft Punk", album="Random Access Memories",
+        album_artist="Daft Punk", track_number=8, year="2013",
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        base = Path(tmp)
+        path = format_track_path(track, base, AudioFormat.MP3_320,
+                                 "{album_artist}/{album}/{track_number:02d} - {title}")
+        assert path == base / "Daft Punk" / "Random Access Memories" / "08 - Get Lucky.mp3", path
+        # Por defecto no debe tocar el disco.
+        assert not path.parent.exists(), "format_track_path no debe crear carpetas por defecto"
+
+        format_track_path(track, base, AudioFormat.MP3_320,
+                          "{album_artist}/{album}/{track_number:02d} - {title}",
+                          create_dirs=True)
+        assert path.parent.exists(), "create_dirs=True debe crear la carpeta"
+
+        # Una plantilla rota cae al nombre plano en vez de reventar.
+        fallback = format_track_path(track, base, AudioFormat.FLAC, "{no_existe}/{title}")
+        assert fallback == base / "Daft Punk - Get Lucky.flac", fallback
+
+        # La extension sigue al formato elegido.
+        assert format_track_path(track, base, AudioFormat.OPUS_160, "{title}").suffix == ".opus"
+    print("  OK rutas, extensiones y fallback de plantilla verificados")
+
+
+def test_audio_format_parsing():
+    print("Testing AudioFormat parsing...")
+    assert AudioFormat.parse("flac") is AudioFormat.FLAC
+    assert AudioFormat.parse("320k") is AudioFormat.MP3_320
+    assert AudioFormat.parse("  M4A  ") is AudioFormat.M4A_256
+    assert AudioFormat.parse("mp3-320") is AudioFormat.MP3_320
+    assert AudioFormat.parse("basura") is None, "un valor invalido debe devolver None"
+    assert AudioFormat.parse("") is None
+    # from_string sigue siendo tolerante para valores ya guardados en disco.
+    assert AudioFormat.from_string("basura") is AudioFormat.MP3_320
+    assert AudioFormat.FLAC.extension == "flac"
+    assert AudioFormat.MP3_128.extension == "mp3"
+    assert "mp3_320" in AudioFormat.choices()
+    print("  OK parse estricto y from_string tolerante")
+
+
+def test_parse_selection():
+    print("Testing parse_selection...")
+    assert parse_selection("q", 5, 2) == ("quit", None)
+    assert parse_selection("s", 5, 2) == ("search", None)
+    assert parse_selection("3", 5, 2) == ("tracks", [2])
+    assert parse_selection("all", 3, 0) == ("tracks", [0, 1, 2])
+    assert parse_selection("1-3", 5, 0) == ("tracks", [0, 1, 2])
+    assert parse_selection("3-1", 5, 0) == ("tracks", [0, 1, 2]), "rango invertido debe ordenarse"
+    assert parse_selection("1,3,5", 5, 0) == ("tracks", [0, 2, 4])
+    assert parse_selection("1,1,2", 5, 0) == ("tracks", [0, 1]), "debe descartar repetidos"
+    assert parse_selection("A2", 5, 3) == ("album", 1)
+
+    # Casos que antes caian en "Opcion no reconocida" sin explicar nada.
+    action, msg = parse_selection("9-20", 5, 0)
+    assert action == "error" and "1-5" in msg, (action, msg)
+    action, msg = parse_selection("A9", 5, 3)
+    assert action == "error" and "A1-A3" in msg, (action, msg)
+    action, msg = parse_selection("", 5, 0)
+    assert action == "error"
+    action, msg = parse_selection("1-x", 5, 0)
+    assert action == "error" and "1-3" in msg
+    action, msg = parse_selection("hola", 5, 0)
+    assert action == "error"
+    action, msg = parse_selection("all", 0, 0)
+    assert action == "error"
+
+    # Un rango parcialmente valido conserva lo que si existe.
+    assert parse_selection("4-8", 5, 0) == ("tracks", [3, 4])
+    print("  OK seleccion, rangos, listas y errores explicados")
+
+
+def test_config_has_no_import_side_effects():
+    print("Testing Config side effects and defaults...")
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg_path = Path(tmp) / "sub" / "config.json"
+        cfg = Config(config_path=cfg_path)
+        # Construir la configuracion no debe escribir nada todavia.
+        assert not cfg_path.exists(), "Config() no debe crear el archivo al arrancar"
+        assert not cfg_path.parent.exists(), "Config() no debe crear directorios al arrancar"
+
+        # Consultar la carpeta de descargas tampoco crea nada.
+        _ = cfg.download_directory
+
+        # Las credenciales no se escriben en el archivo del usuario.
+        cfg.set("embed_cover", False)
+        assert cfg_path.exists()
+        saved = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert "tidal_client_secret" not in saved, "el secreto no debe guardarse en el config"
+        assert saved["embed_cover"] is False
+        # Pero siguen disponibles al leerlas.
+        assert cfg.tidal_client_id == DEFAULT_TIDAL_CLIENT_ID
+        assert cfg.tidal_client_secret == DEFAULT_TIDAL_CLIENT_SECRET
+    print("  OK sin escrituras al importar y sin secretos en el config")
+
+
+def test_config_migrates_legacy_credentials():
+    print("Testing migration of legacy credentials...")
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg_path = Path(tmp) / "config.json"
+        cfg_path.write_text(json.dumps({
+            "embed_cover": True,
+            "tidal_client_id": DEFAULT_TIDAL_CLIENT_ID,
+            "tidal_client_secret": DEFAULT_TIDAL_CLIENT_SECRET,
+        }), encoding="utf-8")
+
+        cfg = Config(config_path=cfg_path)
+        saved = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert "tidal_client_id" not in saved, "las credenciales por defecto deben limpiarse"
+        assert cfg.tidal_client_id == DEFAULT_TIDAL_CLIENT_ID
+
+        # Una credencial personalizada del usuario si se respeta.
+        cfg_path.write_text(json.dumps({"tidal_client_id": "MI_CLAVE"}), encoding="utf-8")
+        cfg2 = Config(config_path=cfg_path)
+        assert cfg2.tidal_client_id == "MI_CLAVE"
+        assert "tidal_client_id" in json.loads(cfg_path.read_text(encoding="utf-8"))
+    print("  OK credenciales por defecto limpiadas y personalizadas respetadas")
+
+
+def test_config_validates_values():
+    print("Testing config value validation...")
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg_path = Path(tmp) / "config.json"
+        cfg_path.write_text(json.dumps({
+            "country_code": "espana", "cover_resolution": "no-es-un-numero",
+            "search_limit": None, "default_format": "inventado",
+        }), encoding="utf-8")
+        cfg = Config(config_path=cfg_path)
+        assert cfg.country_code == "US", cfg.country_code
+        assert cfg.cover_resolution == 1280
+        assert cfg.search_limit == 10
+        assert cfg.default_format is AudioFormat.MP3_320
+
+        cfg_path.write_text(json.dumps({"country_code": "es"}), encoding="utf-8")
+        assert Config(config_path=cfg_path).country_code == "ES"
+
+        # Un archivo corrupto no debe tumbar la aplicacion.
+        cfg_path.write_text("{esto no es json", encoding="utf-8")
+        assert Config(config_path=cfg_path).default_format is AudioFormat.MP3_320
+    print("  OK valores invalidos y archivo corrupto tolerados")
+
+
+def test_image_dimensions():
+    print("Testing image header parsing...")
+    png = (b"\x89PNG\r\n\x1a\n" + b"\x00\x00\x00\x0dIHDR"
+           + (640).to_bytes(4, "big") + (480).to_bytes(4, "big"))
+    assert is_png(png)
+    assert image_dimensions(png) == (640, 480)
+
+    jpeg = (b"\xff\xd8" + b"\xff\xe0" + (16).to_bytes(2, "big") + b"\x00" * 14
+            + b"\xff\xc0" + (17).to_bytes(2, "big") + b"\x08"
+            + (300).to_bytes(2, "big") + (200).to_bytes(2, "big") + b"\x00" * 10)
+    assert not is_png(jpeg)
+    assert image_dimensions(jpeg) == (200, 300)
+
+    # Datos ilegibles no deben lanzar excepcion.
+    assert image_dimensions(b"basura") == (0, 0)
+    print("  OK dimensiones de PNG y JPEG leidas de la cabecera")
+
+
+TESTS = [
+    test_sanitize_filename,
+    test_format_track_path,
+    test_audio_format_parsing,
+    test_parse_selection,
+    test_config_has_no_import_side_effects,
+    test_config_migrates_legacy_credentials,
+    test_config_validates_values,
+    test_image_dimensions,
+]
+
+
+if __name__ == "__main__":
+    for test in TESTS:
+        test()
+    print("\n[ALL UNIT TESTS PASSED SUCCESSFULLY!]")

--- a/install_termux.sh
+++ b/install_termux.sh
@@ -1,0 +1,63 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# Monochrome CLI - Instalador automático para Termux en Android
+
+set -e
+
+echo "=================================================="
+echo "    Instalador de Monochrome CLI para Termux"
+echo "=================================================="
+echo ""
+
+echo "[1/4] Actualizando paquetes e instalando Python y FFmpeg..."
+pkg update -y
+pkg install -y python ffmpeg git libjpeg-turbo
+
+echo ""
+echo "[2/4] Solicitando permisos de almacenamiento en Android..."
+termux-setup-storage || true
+
+echo ""
+echo "[3/4] Instalando dependencias de Python..."
+pip install --upgrade pip
+pip install yt-dlp mutagen rich requests setuptools
+
+echo ""
+echo "[4/4] Configurando comando global 'mono' y 'monochrome'..."
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+pip install -e "$SCRIPT_DIR/cli" || true
+
+# Configurar alias directo de respaldo en bashrc
+ALIAS_LINE="alias mono='python3 $SCRIPT_DIR/mono.py'"
+ALIAS_LINE2="alias monochrome='python3 $SCRIPT_DIR/mono.py'"
+
+# Anade una linea al archivo solo si todavia no esta presente.
+add_alias_line() {
+    rc_file="$1"
+    alias_line="$2"
+    [ -f "$rc_file" ] || return 0
+    grep -qxF "$alias_line" "$rc_file" || echo "$alias_line" >> "$rc_file"
+}
+
+for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
+    add_alias_line "$rc" "$ALIAS_LINE"
+    add_alias_line "$rc" "$ALIAS_LINE2"
+done
+
+echo ""
+if ! command -v ffmpeg >/dev/null 2>&1; then
+    echo "  ⚠ AVISO: FFmpeg no quedó instalado. Sin él no se puede convertir el audio."
+    echo "    Instálalo con: pkg install ffmpeg"
+    echo ""
+fi
+
+echo "=================================================="
+echo "  ✔ ¡Instalación de Monochrome CLI completada!"
+echo "=================================================="
+echo ""
+echo "Puedes iniciar la app ejecutando:"
+echo "   mono"
+echo ""
+echo "O buscar directamente una canción con:"
+echo "   mono 'nombre de la cancion'"
+echo "   mono -f flac 'nombre de la cancion'"
+echo ""

--- a/mono.py
+++ b/mono.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""
+Monochrome CLI launcher script.
+"""
+import sys
+from pathlib import Path
+
+# Add cli directory to sys.path
+cli_dir = Path(__file__).resolve().parent / "cli"
+if str(cli_dir) not in sys.path:
+    sys.path.insert(0, str(cli_dir))
+
+from monochrome_cli.main import cli_entrypoint
+
+if __name__ == "__main__":
+    cli_entrypoint()


### PR DESCRIPTION
CLI/TUI para buscar y descargar música desde la terminal: metadatos y carátulas de Tidal (con Deezer de respaldo), audio vía `yt-dlp`, etiquetado con Mutagen y letras sincronizadas de LRCLIB. Funciona en Linux, macOS y Termux.

## Correcciones incluidas sobre la primera versión del paquete

**Empaquetado**
- Faltaban los `__init__.py` de `core/`, `ui/` y `utils/`: `pip install .` instalaba un paquete sin esos módulos y `mono` fallaba con `ModuleNotFoundError`. Solo funcionaba con `pip install -e`, que es lo que usaban el README y el instalador.

**Calidad y correspondencia del audio**
- Se elige el resultado de YouTube cuya duración coincide con la del catálogo (±4 s). Antes se descargaba el primer resultado: en la prueba con *Get Lucky* bajaba el radio edit de 247 s etiquetado como la versión de álbum de 370 s, y el `.lrc` quedaba desincronizado.
- Perfiles de descarga en cascada: primero el stream de solo audio (~130 kbps) y, si YouTube lo bloquea, el progresivo de respaldo. Fijar `player_client` a `web`/`android` dejaba a yt-dlp sin ningún formato adaptativo, cayendo siempre al formato 18 (~48 kbps).

**Metadatos**
- Portadas en Opus y OGG vía `METADATA_BLOCK_PICTURE`, con dimensiones leídas de la cabecera PNG/JPEG. Antes el ajuste "incrustar portadas" no hacía nada en esos formatos.
- `--lyrics` / `--no-lyrics` mandan sobre la configuración guardada; antes se ignoraban si las letras estaban desactivadas.
- La letra se pide a LRCLIB con la duración real del audio descargado.
- El archivo temporal solo se acepta con la extensión esperada, en vez de mover un `.webm` o un `.part` al destino final y reportarlo como éxito.

**Documentación honesta**
- El audio procede de YouTube, así que ningún formato de salida es realmente sin pérdida. Se retiraron los textos que prometían "Lossless / Hi-Res 16-24 bit" y la columna "Calidad" pasa a indicar el origen de los metadatos.
- Documentada la diferencia entre `api.tidal.com/v1` (interna, la que usa el proyecto) y `openapi.tidal.com/v2` (oficial): las credenciales del portal de desarrolladores no funcionan con los endpoints actuales.

**Configuración y CLI**
- Credenciales de Tidal fuera del `config.json` del usuario, con soporte de variables de entorno y migración automática de los archivos existentes.
- País del catálogo configurable (antes `countryCode=US` fijo).
- Validación de `--format`, `--set-default-format` y `--set-default-country`, que antes aceptaban cualquier cosa en silencio.
- Selección del menú extraída a `parse_selection()` con mensajes de error concretos; se añadió la opción de sobrescribir en el TUI.
- La configuración solo se escribe al cambiar algo y consultar rutas ya no crea directorios.
- Comprobación de FFmpeg antes de descargar, con el comando de instalación de cada plataforma.

**Instalador**
- El alias `monochrome` nunca se añadía por una redirección mal puesta; reescrito con una función idempotente para `.bashrc` y `.zshrc`.

**Tests**
- Nuevo `tests/test_units.py` con 8 casos sin red y `tests/conftest.py` que aísla las pruebas en vivo tras `MONOCHROME_LIVE_TESTS=1`: `pytest tests/` pasa en 0,4 s en vez de lanzar descargas reales.
- Reparado `test_artist_downloads.py`, que no podía ejecutarse (tupla sin desempaquetar, `NameError`, y f-strings con comillas anidadas que rompían en Python 3.8-3.11).

## Verificación

Las 5 suites en vivo y las unitarias pasan; instalación limpia con `pip install .` verificada en un target aislado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Monochrome CLI/TUI for searching, selecting, and downloading music.
  * Supports Tidal and Deezer search, album downloads, batch processing, and duplicate detection.
  * Added MP3, FLAC, M4A, Opus, and OGG output formats.
  * Added metadata, cover art, and optional lyrics embedding.
  * Added persistent settings, configurable paths, FFmpeg checks, and Termux support.
  * Added installation scripts, launcher commands, and Spanish documentation.

* **Tests**
  * Added unit, integration, tagging, lyrics, search, and download coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->