### PR TITLE
import autoeq presets

### DIFF
--- a/index.html
+++ b/index.html
@@ -5086,6 +5086,14 @@
 
                                         <div class="autoeq-actions-row">
                                             <button
+                                                id="autoeq-import-preset-btn"
+                                                class="autoeq-download-btn"
+                                                title="Import EQ settings"
+                                                aria-label="Import EQ settings"
+                                            >
+                                                <use svg="!lucide/upload.svg" size="20" />
+                                            </button>
+                                            <button
                                                 id="autoeq-download-btn"
                                                 class="autoeq-download-btn"
                                                 title="Export EQ settings"
@@ -5093,6 +5101,12 @@
                                             >
                                                 <use svg="!lucide/download.svg" size="20" />
                                             </button>
+                                            <input
+                                                type="file"
+                                                id="autoeq-import-preset-file"
+                                                accept=".txt,.csv"
+                                                style="display: none"
+                                            />
                                         </div>
                                         <span
                                             id="autoeq-status"

--- a/js/settings.js
+++ b/js/settings.js
@@ -2077,6 +2077,8 @@ export async function initializeSettings(scrobbler, player, api, ui) {
     };
     const autoeqRunBtn = document.getElementById('autoeq-run-btn');
     const autoeqDownloadBtn = document.getElementById('autoeq-download-btn');
+    const autoeqImportPresetBtn = document.getElementById('autoeq-import-preset-btn');
+    const autoeqImportPresetFile = document.getElementById('autoeq-import-preset-file');
     const autoeqStatus = document.getElementById('autoeq-status');
     const autoeqImportBtn = document.getElementById('autoeq-import-measurement-btn');
     const autoeqImportFile = document.getElementById('autoeq-import-measurement-file');
@@ -4669,6 +4671,40 @@ export async function initializeSettings(scrobbler, player, api, ui) {
     // ========================================
     // Parametric EQ Import/Export
     // ========================================
+    const parseParametricEQ = (text) => {
+        const bands = [];
+        let preamp = 0;
+        for (const line of text.split('\n')) {
+            const preampMatch = line.match(/Preamp:\s*([-\d.]+)\s*dB/i);
+            if (preampMatch) {
+                preamp = parseFloat(preampMatch[1]);
+                continue;
+            }
+            const filterMatch = line.match(
+                /Filter\s+\d+:\s*ON\s+(\w+)\s+Fc\s+([\d.]+)\s*Hz\s+Gain\s+([-\d.]+)\s*dB\s+Q\s+([\d.]+)/i
+            );
+            if (filterMatch) {
+                const typeMap = {
+                    PK: 'peaking',
+                    LS: 'lowshelf',
+                    LSC: 'lowshelf',
+                    LSF: 'lowshelf',
+                    HS: 'highshelf',
+                    HSC: 'highshelf',
+                    HSF: 'highshelf',
+                };
+                bands.push({
+                    id: bands.length,
+                    type: typeMap[filterMatch[1].toUpperCase()] || 'peaking',
+                    freq: parseFloat(filterMatch[2]),
+                    gain: parseFloat(filterMatch[3]),
+                    q: parseFloat(filterMatch[4]),
+                    enabled: true,
+                });
+            }
+        }
+        return { bands, preamp };
+    };
     const parametricExportBtn = document.getElementById('parametric-export-btn');
     const parametricImportBtn = document.getElementById('parametric-import-btn');
     const parametricImportFile = document.getElementById('parametric-import-file');
@@ -4703,39 +4739,7 @@ export async function initializeSettings(scrobbler, player, api, ui) {
             const reader = new FileReader();
             reader.onload = (event) => {
                 try {
-                    const text = event.target.result;
-                    const bands = [];
-                    let preamp = 0;
-                    const lines = text.split('\n');
-                    for (const line of lines) {
-                        const preampMatch = line.match(/Preamp:\s*([-\d.]+)\s*dB/i);
-                        if (preampMatch) {
-                            preamp = parseFloat(preampMatch[1]);
-                            continue;
-                        }
-                        const filterMatch = line.match(
-                            /Filter\s+\d+:\s*ON\s+(\w+)\s+Fc\s+([\d.]+)\s*Hz\s+Gain\s+([-\d.]+)\s*dB\s+Q\s+([\d.]+)/i
-                        );
-                        if (filterMatch) {
-                            const typeMap = {
-                                PK: 'peaking',
-                                LS: 'lowshelf',
-                                LSC: 'lowshelf',
-                                LSF: 'lowshelf',
-                                HS: 'highshelf',
-                                HSC: 'highshelf',
-                                HSF: 'highshelf',
-                            };
-                            bands.push({
-                                id: bands.length,
-                                type: typeMap[filterMatch[1].toUpperCase()] || 'peaking',
-                                freq: parseFloat(filterMatch[2]),
-                                gain: parseFloat(filterMatch[3]),
-                                q: parseFloat(filterMatch[4]),
-                                enabled: true,
-                            });
-                        }
-                    }
+                    const { bands, preamp } = parseParametricEQ(event.target.result);
                     if (bands.length === 0) return;
                     parametricBands = bands;
                     applyBandsToAudio(parametricBands);
@@ -4749,6 +4753,45 @@ export async function initializeSettings(scrobbler, player, api, ui) {
                 } catch (err) {
                     console.error('[PEQ Import] Failed:', err);
                 }
+            };
+            reader.readAsText(file);
+            e.target.value = '';
+        });
+    }
+
+    if (autoeqImportPresetBtn && autoeqImportPresetFile) {
+        autoeqImportPresetBtn.addEventListener('click', () => autoeqImportPresetFile.click());
+        autoeqImportPresetFile.addEventListener('change', (e) => {
+            const file = e.target.files[0];
+            if (!file) return;
+            const reader = new FileReader();
+            reader.onload = (event) => {
+                const { bands, preamp } = parseParametricEQ(event.target.result);
+                if (!bands.length) return setAutoEQStatus('Invalid EQ preset', 'error');
+                const name = file.name.replace(/\.(txt|csv)$/i, '');
+                autoeqCurrentBands = bands;
+                autoeqSelectedMeasurement = null;
+                autoeqSelectedEntry = { name, type: 'over-ear' };
+                const id = equalizerSettings.saveAutoEQProfile({
+                    id: 'autoeq_' + Date.now(),
+                    name,
+                    headphoneName: name,
+                    headphoneType: 'over-ear',
+                    targetId: autoeqTargetSelect?.value,
+                    targetLabel: 'Imported',
+                    bandCount: bands.length,
+                    maxFreq: parseInt(autoeqMaxFreq?.value, 10) || 16000,
+                    sampleRate: parseInt(autoeqSampleRate?.value, 10) || 48000,
+                    bands,
+                    preamp,
+                    measurementData: [],
+                    targetData: [],
+                    correctedData: [],
+                    createdAt: Date.now(),
+                });
+                equalizerSettings.setActiveAutoEQProfile(id);
+                renderSavedProfiles();
+                setAutoEQStatus(`Imported "${name}"`, 'success');
             };
             reader.readAsText(file);
             e.target.value = '';


### PR DESCRIPTION
fixes #752

- 🤖 opsectron3000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing AutoEQ presets from `.txt` and `.csv` files.
  * Imported presets are validated, converted into profiles, saved, and displayed in the saved-profile list.
  * Added status messages to indicate import results.
  * Improved parametric EQ preset parsing for Equalizer APO-compatible files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->